### PR TITLE
[FG:InPlacePodVerticalScaling] Add mustKeepCPUs Interface

### DIFF
--- a/pkg/api/pod/testing/make.go
+++ b/pkg/api/pod/testing/make.go
@@ -281,6 +281,12 @@ func SetContainerResources(rr api.ResourceRequirements) TweakContainer {
 	}
 }
 
+func SetContainerEnv(env []api.EnvVar) TweakContainer {
+	return func(cnr *api.Container) {
+		cnr.Env = env
+	}
+}
+
 func SetContainerPorts(ports ...api.ContainerPort) TweakContainer {
 	return func(cnr *api.Container) {
 		cnr.Ports = ports

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
+	"k8s.io/utils/cpuset"
 )
 
 const isNegativeErrorMsg string = apimachineryvalidation.IsNegativeErrorMsg
@@ -5575,6 +5576,16 @@ func ValidatePodEphemeralContainersUpdate(newPod, oldPod *core.Pod, opts PodVali
 	return allErrs
 }
 
+func removeEnvVar(envs []core.EnvVar, nameToRemove string) []core.EnvVar {
+    var newEnvs []core.EnvVar
+    for _, env := range envs {
+        if env.Name != nameToRemove {
+            newEnvs = append(newEnvs, env)
+        }
+    }
+    return newEnvs
+}
+
 // ValidatePodResize tests that a user update to pod container resources is valid.
 // newPod and oldPod must only differ in their Containers[*].Resources and
 // Containers[*].ResizePolicy field.
@@ -5666,6 +5677,35 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 		req := dropCPUMemoryUpdates(container.Resources.Requests, oldPod.Spec.Containers[ix].Resources.Requests)
 		container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
 		container.ResizePolicy = oldPod.Spec.Containers[ix].ResizePolicy // +k8s:verify-mutation:reason=clone
+                // the element named "mustKeepCPUs" in env can be update or add
+		var existNewMustKeepCPUs bool = false
+		var existOldMustKeepCPUs bool = false
+		for jx, newEnv := range container.Env {
+			if newEnv.Name == "mustKeepCPUs" {
+				existNewMustKeepCPUs = true
+				_, err := cpuset.Parse(newEnv.Value)
+				if err != nil {
+					allErrs = append(allErrs, field.Invalid(fldPath, newEnv, "Check mustKeepCPUs format, only number \",\" and \"-\" are allowed"))
+				}
+				//change mustKeepCPUs
+				for _, oldEnv := range oldPod.Spec.Containers[ix].Env {
+					if oldEnv.Name == "mustKeepCPUs" {
+						existOldMustKeepCPUs = true
+						container.Env[jx] = oldEnv
+						break
+					}
+				}
+				//add mustKeepCPUs
+				if existOldMustKeepCPUs == false && (len(container.Env)-len(oldPod.Spec.Containers[ix].Env)) == 1 {
+					container.Env = removeEnvVar(container.Env, "mustKeepCPUs") //delete "mustKeepCPUs" in newPod to make newPod equal to oldPod
+				}
+				break
+			}
+		}
+		//delete mustKeepCPUs
+		if existNewMustKeepCPUs == false && (len(oldPod.Spec.Containers[ix].Env)-len(container.Env)) == 1 {
+			oldPod.Spec.Containers[ix].Env = removeEnvVar(oldPod.Spec.Containers[ix].Env, "mustKeepCPUs")
+		}
 		newContainers = append(newContainers, container)
 	}
 	originalCPUMemPodSpec.Containers = newContainers

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -25624,6 +25624,46 @@ func TestValidatePodResize(t *testing.T) {
 		)...)
 	}
 
+	mkPodWith1Env := func(envName1, envValue1 string, tweaks ...podtest.Tweak) *core.Pod {
+		return podtest.MakePod("pod", append(tweaks,
+			podtest.SetContainers(
+				podtest.MakeContainer(
+					"container",
+					podtest.SetContainerEnv(
+						[]core.EnvVar{
+							{
+								Name: envName1,
+								Value: envValue1,
+							},
+						},
+					),
+				),
+			),
+		)...)
+	}
+
+	mkPodWith2Env := func(envName1, envValue1, envName2, envValue2 string, tweaks ...podtest.Tweak) *core.Pod {
+		return podtest.MakePod("pod", append(tweaks,
+			podtest.SetContainers(
+				podtest.MakeContainer(
+					"container",
+					podtest.SetContainerEnv(
+						[]core.EnvVar{
+							{
+								Name: envName1,
+								Value: envValue1,
+							},
+							{
+								Name: envName2,
+								Value: envValue2,
+							},
+						},
+					),
+				),
+			),
+		)...)
+	}
+
 	tests := []struct {
 		test string
 		old  *core.Pod
@@ -25985,6 +26025,42 @@ func TestValidatePodResize(t *testing.T) {
 			})),
 			new: mkPod(core.ResourceList{}, getResources("200m", "0", "1Gi", "")),
 			err: "",
+		},
+		{
+			test: "Pod env:mustKeepCPUs change value",
+			old:  mkPodWith2Env("env1", "a","mustKeepCPUs", "0"),
+			new:  mkPodWith2Env("env1", "a","mustKeepCPUs", "1"),
+			err:  "",
+		},
+		{
+			test: "Pod env:mustKeepCPUs add",
+			old:  mkPodWith1Env("env1", "a"),
+			new:  mkPodWith2Env("env1", "a","mustKeepCPUs", "1"),
+			err:  "",
+		},
+		{
+			test: "Pod env:mustKeepCPUs delete",
+			old:  mkPodWith2Env("env1", "a","mustKeepCPUs", "1"),
+			new:  mkPodWith1Env("env1", "a"),
+			err:  "",
+		},
+		{
+			test: "Pod env:env1 change is forbidden",
+			old:  mkPodWith2Env("env1", "a","mustKeepCPUs", "0"),
+			new:  mkPodWith2Env("env1", "b","mustKeepCPUs", "0"),
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		},
+		{
+			test: "Pod env:env1 add is forbidden",
+			old:  mkPodWith1Env("mustKeepCPUs", "0"),
+			new:  mkPodWith2Env("env1", "a","mustKeepCPUs", "1"),
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		},
+		{
+			test: "Pod env:env1 delete is forbidden",
+			old:  mkPodWith2Env("env1", "a","mustKeepCPUs", "1"),
+			new:  mkPodWith1Env("mustKeepCPUs", "0"),
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
 		},
 	}
 


### PR DESCRIPTION
What type of PR is this?
kind/design

This PR is based on the https://github.com/esotsal/kubernetes/tree/policy_static.
This PR replace https://github.com/Nordix/kubernetes/pull/7.

What this PR does / why we need it:
When Guaranteed QoS Class Pod scale down without restart with Static CPU management policy alongside InPlacePodVerticalScaling, specify mustKeepCPUsForResize is necessary.

Because if the delay-sensitive service is processed in a guaranteed Pod, and CPU affinity are set for delay-sensitive processes.
If the cpuset changes a lot and do not know which CPU will be removed, the severe CPU migrate will have impact for delay-sensitive process.
In addition, the process in scaled Pod should share newly added CPUs with other Pod for a while(because of cpuset update one Pod by one pod from the start of reconcile period), This may have big impact on latency-sensitive service.

https://github.com/kubernetes/kubernetes/pull/123319#issuecomment-2431197508

Which issue(s) this PR fixes:
Add the interface for mustKeepCPUsForResize when scale down

Does this PR introduce a user-facing change?
The "mustKeepCPUs" in env can be changed by patch command