### PR TITLE
[FG:InPlacePodVerticalScaling] A proposal for CPU allocated strategy when Pod scale up and down

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -98,6 +98,11 @@ type numaOrSocketsFirstFuncs interface {
 	sortAvailableNUMANodes() []int
 	sortAvailableSockets() []int
 	sortAvailableCores() []int
+	takeFullFirstLevelForResize()
+	takeFullSecondLevelForResize()
+	sortAvailableNUMANodesForResize() []int
+	sortAvailableSocketsForResize() []int
+	sortAvailableCoresForResize() []int
 }
 
 type numaFirst struct{ acc *cpuAccumulator }
@@ -207,8 +212,145 @@ func (s *socketsFirst) sortAvailableCores() []int {
 	return result
 }
 
+// If NUMA nodes are higher in the memory hierarchy than sockets, then we take
+// from the set of NUMA Nodes as the first level for resize.
+func (n *numaFirst) takeFullFirstLevelForResize() {
+	n.acc.takeRemainCpusForFullNUMANodes()
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then we take
+// from the set of sockets as the second level for resize.
+func (n *numaFirst) takeFullSecondLevelForResize() {
+	n.acc.takeRemainCpusForFullSockets()
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then return the available NUMA nodes
+// which have allocated CPUs to Container.
+func (n *numaFirst) sortAvailableNUMANodesForResize() []int {
+    allocatedNumaNodesSet := n.acc.resultDetails.NUMANodes()
+	availableNumaNodesSet := n.acc.details.NUMANodes()
+	numas := allocatedNumaNodesSet.Intersection(availableNumaNodesSet).UnsortedList()
+	n.acc.sort(numas, n.acc.details.CPUsInNUMANodes)
+	return numas
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, 
+// Firstly, pull the socket which are allocated CPUs to the Container
+// Secondly, pull the other sockets which are not allocated CPUs to the Container, but contains in the NUMA node which are allocated CPUs to the Container
+func (n *numaFirst) sortAvailableSocketsForResize() []int {
+	var result []int
+
+	//Sort allocated sockets
+	allocatedSocketsSet := n.acc.resultDetails.Sockets()
+	availableSocketsSet := n.acc.details.Sockets()
+	allocatedSockets := allocatedSocketsSet.Intersection(availableSocketsSet).UnsortedList()
+	n.acc.sort(allocatedSockets, n.acc.details.CPUsInSockets)
+	result = append(result, allocatedSockets...)
+
+	//Sort the sockets in allocated numa node, but not allocated CPU on these sockets
+	for _, numa := range n.sortAvailableNUMANodesForResize() {
+		socketSet := n.acc.details.SocketsInNUMANodes(numa)
+		sockets := socketSet.Difference(allocatedSocketsSet).UnsortedList()
+		n.acc.sort(sockets, n.acc.details.CPUsInSockets)
+		result = append(result, sockets...)
+	}
+	return result
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, 
+// Firstly, pull the cores which are allocated CPUs to the Container
+// Secondly, pull the other cores which are not allocated CPUs to the Container, but contains in the NUMA node which are allocated CPUs to the Container
+func (n *numaFirst) sortAvailableCoresForResize() []int {
+	var result []int
+
+	//Sort allocated cores
+	allocatedCoresSet := n.acc.resultDetails.Cores()
+	availableCoresSet := n.acc.details.Cores()
+	allocatedCores := allocatedCoresSet.Intersection(availableCoresSet).UnsortedList()
+	n.acc.sort(allocatedCores, n.acc.details.CPUsInCores)
+	result = append(result, allocatedCores...)
+
+	//Sort the cores in allocated sockets, and allocated numa, but not allocated CPU on these sockets and numa
+	for _, socket := range n.acc.sortAvailableSocketsForResize() {
+		coresSet := n.acc.details.CoresInSockets(socket)
+		cores := coresSet.Difference(allocatedCoresSet).UnsortedList()
+		n.acc.sort(cores, n.acc.details.CPUsInCores)
+		result = append(result, cores...)
+	}
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then we take
+// from the set of NUMA Nodes as the first level for resize.
+func (s *socketsFirst) takeFullFirstLevelForResize() {
+	s.acc.takeRemainCpusForFullSockets()
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then we take
+// from the set of sockets as the second level for resize.
+func (s *socketsFirst) takeFullSecondLevelForResize() {
+	s.acc.takeRemainCpusForFullNUMANodes()
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, 
+// Firstly, pull the NUMA nodes which are allocated CPUs to the Container
+// Secondly, pull the other NUMA nodes which are not allocated CPUs to the Container, but contains in the sockets which are allocated CPUs to the Container
+func (s *socketsFirst) sortAvailableNUMANodesForResize() []int {
+	var result []int
+
+	//Sort allocated sockets
+	allocatedNUMANodesSet := s.acc.resultDetails.NUMANodes()
+	availableNUMANodesSet := s.acc.details.NUMANodes()
+	allocatedNUMANodes := allocatedNUMANodesSet.Intersection(availableNUMANodesSet).UnsortedList()
+	s.acc.sort(allocatedNUMANodes, s.acc.details.CPUsInNUMANodes)
+	result = append(result, allocatedNUMANodes...)
+
+	//Sort the sockets in allocated numa node, but not allocated CPU on these sockets
+	for _, socket := range s.sortAvailableSocketsForResize() {
+		NUMANodesSet := s.acc.details.NUMANodesInSockets(socket)
+		NUMANodes := NUMANodesSet.Difference(allocatedNUMANodesSet).UnsortedList()
+		s.acc.sort(NUMANodes, s.acc.details.CPUsInNUMANodes)
+		result = append(result, NUMANodes...)
+	}
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then return the available sockets
+// which have allocated CPUs to Container.
+func (s *socketsFirst) sortAvailableSocketsForResize() []int {
+    allocatedSocketsSet := s.acc.resultDetails.Sockets()
+	availableSocketsSet := s.acc.details.Sockets()
+	sockets := allocatedSocketsSet.Intersection(availableSocketsSet).UnsortedList()
+	s.acc.sort(sockets, s.acc.details.CPUsInSockets)
+	return sockets
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, 
+// Firstly, pull the cores which are allocated CPUs to the Container
+// Secondly, pull the other cores which are not allocated CPUs to the Container, but contains in the socket which are allocated CPUs to the Container
+func (s *socketsFirst) sortAvailableCoresForResize() []int {
+	var result []int
+
+	//Sort allocated cores
+	allocatedCoresSet := s.acc.resultDetails.Cores()
+	availableCoresSet := s.acc.details.Cores()
+	allocatedCores := allocatedCoresSet.Intersection(availableCoresSet).UnsortedList()
+	s.acc.sort(allocatedCores, s.acc.details.CPUsInCores)
+	result = append(result, allocatedCores...)
+
+	//Sort the cores in allocated sockets, and allocated numa, but not allocated CPU on these sockets and numa
+	for _, NUMANode := range s.acc.sortAvailableNUMANodesForResize() {
+		coresSet := s.acc.details.CoresInNUMANodes(NUMANode)
+		cores := coresSet.Difference(allocatedCoresSet).UnsortedList()
+		s.acc.sort(cores, s.acc.details.CPUsInCores)
+		result = append(result, cores...)
+	}
+	return result
+}
+
 type availableCPUSorter interface {
 	sort() []int
+	sortForResize() []int
 }
 
 type sortCPUsPacked struct{ acc *cpuAccumulator }
@@ -223,6 +365,14 @@ func (s sortCPUsPacked) sort() []int {
 
 func (s sortCPUsSpread) sort() []int {
 	return s.acc.sortAvailableCPUsSpread()
+}
+
+func (s sortCPUsPacked) sortForResize() []int {
+	return s.acc.sortAvailableCPUsPackedForResize()
+}
+
+func (s sortCPUsSpread) sortForResize() []int {
+	return s.acc.sortAvailableCPUsSpreadForResize()
 }
 
 // CPUSortingStrategy describes the CPU sorting solution within the socket scope.
@@ -285,6 +435,9 @@ type cpuAccumulator struct {
 	// cardinality equal to the total number of CPUs to accumulate.
 	result cpuset.CPUSet
 
+	// `resultDetails` is the set of allocated CPUs in `result`
+	resultDetails topology.CPUDetails
+
 	numaOrSocketsFirst numaOrSocketsFirstFuncs
 
 	// availableCPUSorter is used to control the cpu sorting result.
@@ -300,6 +453,7 @@ func newCPUAccumulator(topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, 
 		details:       topo.CPUDetails.KeepOnly(availableCPUs),
 		numCPUsNeeded: numCPUs,
 		result:        cpuset.New(),
+		resultDetails:  topo.CPUDetails.KeepOnly(cpuset.New()),
 	}
 
 	if reusableCPUsForResize != nil {
@@ -425,6 +579,21 @@ func (a *cpuAccumulator) freeCores() []int {
 // Returns free CPU IDs as a slice sorted by sortAvailableCPUsPacked().
 func (a *cpuAccumulator) freeCPUs() []int {
 	return a.availableCPUSorter.sort()
+}
+
+//return true if this numa only allocated CPUs for this Container 
+func (a *cpuAccumulator) isFullNUMANodeForResize(numaID int) bool {
+	return a.resultDetails.CPUsInNUMANodes(numaID).Size() + a.details.CPUsInNUMANodes(numaID).Size() == a.topo.CPUDetails.CPUsInNUMANodes(numaID).Size()
+}
+
+//return true if this Socket only allocated CPUs for this Container 
+func (a *cpuAccumulator) isFullSocketForResize(socketID int) bool {
+	return a.resultDetails.CPUsInSockets(socketID).Size() + a.details.CPUsInSockets(socketID).Size() == a.topo.CPUsPerSocket()
+}
+
+//return true if this Socket only allocated CPUs for this Container 
+func (a *cpuAccumulator) isFullCoreForResize(coreID int) bool {
+	return a.resultDetails.CPUsInCores(coreID).Size() + a.details.CPUsInCores(coreID).Size() == a.topo.CPUsPerCore()
 }
 
 // Sorts the provided list of NUMA nodes/sockets/cores/cpus referenced in 'ids'
@@ -556,8 +725,107 @@ func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 	return result
 }
 
+// Sort all NUMA nodes with at least one free CPU.
+//
+// If NUMA nodes are higher than sockets in the memory hierarchy, they are sorted by ascending number
+// of free CPUs that they contain. "higher than sockets in the memory hierarchy" means that NUMA nodes
+// contain a bigger number of CPUs (free and busy) than sockets, or equivalently that each NUMA node
+// contains more than one socket.
+//
+// If instead NUMA nodes are lower in the memory hierarchy than sockets, they are sorted as follows.
+// First part, sort the NUMA nodes which contains the CPUs allocated to Container. and these NUMA nodes 
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the NUMA nodes contained in the sockets which contains the CPUs allocated to Container, 
+// but exclude the NUMA nodes in first part. these NUMA nodes sorted by the rule as below
+//   First, they are sorted by number of free CPUs in the sockets that contain them. Then, for each
+//   socket they are sorted by number of free CPUs that they contain. The order is always ascending.
+func (a *cpuAccumulator) sortAvailableNUMANodesForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableNUMANodesForResize()
+}
+
+// Sort all sockets with at least one free CPU.
+//
+// If sockets are higher than NUMA nodes in the memory hierarchy, they are sorted by ascending number
+// of free CPUs that they contain. "higher than NUMA nodes in the memory hierarchy" means that
+// sockets contain a bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each
+// socket contains more than one NUMA node.
+//
+// If instead sockets are lower in the memory hierarchy than NUMA nodes, they are sorted as follows.
+// First part, sort the sockets which contains the CPUs allocated to Container. and these sockets 
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the sockets contained in the NUMA nodes which contains the CPUs allocated to Container, 
+// but exclude the sockets in first part. these sockets sorted by the rule as below
+//   First, they are sorted by number of free CPUs in the NUMA nodes that contain them. Then, for each
+//   NUMA node they are sorted by number of free CPUs that they contain. The order is always ascending.
+func (a *cpuAccumulator) sortAvailableSocketsForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableSocketsForResize()
+}
+
+// Sort all cores with at least one free CPU.
+//
+// If sockets are higher in the memory hierarchy than NUMA nodes, meaning that sockets contain a
+// bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each socket contains
+// more than one NUMA node, the cores are sorted as follows. 
+// First part, sort the cores which contains the CPUs allocated to Container. and these cores 
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the cores contained in the NUMA nodes which contains the CPUs allocated to Container, 
+// but exclude the cores in first part. these cores sorted by the rule as below
+// First, they are sorted by number of
+// free CPUs that their sockets contain. Then, for each socket, the cores in it are sorted by number
+// of free CPUs that their NUMA nodes contain. Then, for each NUMA node, the cores in it are sorted
+// by number of free CPUs that they contain. The order is always ascending. 
+
+// If instead NUMA nodes are higher in the memory hierarchy than sockets, the sorting happens in the
+// same way as described in the previous paragraph.
+func (a *cpuAccumulator) sortAvailableCoresForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableCoresForResize()
+}
+
+
+// Sort all free CPUs.
+//
+// If sockets are higher in the memory hierarchy than NUMA nodes, meaning that sockets contain a
+// bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each socket contains
+// more than one NUMA node, the CPUs are sorted as follows. 
+// First part, sort the cores which contains the CPUs allocated to Container. and these cores 
+// are sorted by number of free CPUs that they contain. for each core, the CPUs in it are
+// sorted by numerical ID.
+// Second part, sort the cores contained in the NUMA nodes which contains the CPUs allocated to Container, 
+// but exclude the cores in first part. these cores sorted by the rule as below
+// First, they are sorted by number of
+// free CPUs that their sockets contain. Then, for each socket, the CPUs in it are sorted by number
+// of free CPUs that their NUMA nodes contain. Then, for each NUMA node, the CPUs in it are sorted
+// by number of free CPUs that their cores contain. Finally, for each core, the CPUs in it are
+// sorted by numerical ID. The order is always ascending. 
+//
+// If instead NUMA nodes are higher in the memory hierarchy than sockets, the sorting happens in the
+// same way as described in the previous paragraph.
+func (a *cpuAccumulator) sortAvailableCPUsPackedForResize() []int {
+	var result []int
+	for _, core := range a.sortAvailableCoresForResize() {
+		cpus := a.details.CPUsInCores(core).UnsortedList()
+		sort.Ints(cpus)
+		result = append(result, cpus...)
+	}
+	return result
+}
+
+// Sort all available CPUs:
+// - First by core using sortAvailableSocketsForResize().
+// - Then within each socket, sort cpus directly using the sort() algorithm defined above.
+func (a *cpuAccumulator) sortAvailableCPUsSpreadForResize() []int {
+	var result []int
+	for _, socket := range a.sortAvailableSocketsForResize() {
+		cpus := a.details.CPUsInSockets(socket).UnsortedList()
+		sort.Ints(cpus)
+		result = append(result, cpus...)
+	}
+	return result
+}
+
 func (a *cpuAccumulator) take(cpus cpuset.CPUSet) {
 	a.result = a.result.Union(cpus)
+	a.resultDetails = a.topo.CPUDetails.KeepOnly(a.result)
 	a.details = a.details.KeepOnly(a.details.CPUs().Difference(a.result))
 	a.numCPUsNeeded -= cpus.Size()
 }
@@ -654,6 +922,56 @@ func (a *cpuAccumulator) takeFullCores() {
 func (a *cpuAccumulator) takeRemainingCPUs() {
 	for _, cpu := range a.availableCPUSorter.sort() {
 		klog.V(4).InfoS("takeRemainingCPUs: claiming CPU", "cpu", cpu)
+		a.take(cpuset.New(cpu))
+		if a.isSatisfied() {
+			return
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeRemainCpusForFullNUMANodes() {
+	for _, numa := range a.sortAvailableNUMANodesForResize() {
+		if a.isFullNUMANodeForResize(numa){
+			cpusInNUMANode := a.details.CPUsInNUMANodes(numa)
+			if !a.needsAtLeast(cpusInNUMANode.Size()) {
+				continue
+			}
+			klog.V(4).InfoS("takeRemainCpusForFullNUMANodes: claiming NUMA node", "numa", numa, "cpusInNUMANode", cpusInNUMANode)
+			a.take(cpusInNUMANode)
+	    }
+	}
+}
+
+func (a *cpuAccumulator) takeRemainCpusForFullSockets() {
+	for _, socket := range a.sortAvailableSocketsForResize() {
+		if a.isFullSocketForResize(socket){
+			cpusInSocket := a.details.CPUsInSockets(socket)
+			if !a.needsAtLeast(cpusInSocket.Size()) {
+				continue
+			}
+			klog.V(4).InfoS("takeRemainCpusForFullSockets: claiming Socket", "socket", socket, "cpusInSocket", cpusInSocket)
+			a.take(cpusInSocket)
+	    }
+	}
+}
+
+
+func (a *cpuAccumulator) takeRemainCpusForFullCores() {
+	for _, core := range a.sortAvailableCoresForResize() {
+		if a.isFullCoreForResize(core){
+			cpusInCore := a.details.CPUsInCores(core)
+			if !a.needsAtLeast(cpusInCore.Size()) {
+				continue
+			}
+			klog.V(4).InfoS("takeRemainCpusForFullCores: claiming Core", "core", core, "cpusInCore", cpusInCore)
+			a.take(cpusInCore)
+	    }
+	}
+}
+
+func (a *cpuAccumulator) takeRemainingCPUsForResize() {
+	for _, cpu := range a.availableCPUSorter.sortForResize() {
+		klog.V(4).InfoS("takeRemainingCPUsForResize: claiming CPU", "cpu", cpu)
 		a.take(cpuset.New(cpu))
 		if a.isSatisfied() {
 			return
@@ -809,7 +1127,15 @@ func takeByTopologyNUMAPacked(topo *topology.CPUTopology, availableCPUs cpuset.C
 	//    requires at least a NUMA node or socket's-worth of CPUs. If NUMA
 	//    Nodes map to 1 or more sockets, pull from NUMA nodes first.
 	//    Otherwise pull from sockets first.
+	acc.numaOrSocketsFirst.takeFullFirstLevelForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
 	acc.numaOrSocketsFirst.takeFullFirstLevel()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+	acc.numaOrSocketsFirst.takeFullSecondLevelForResize()
 	if acc.isSatisfied() {
 		return acc.result, nil
 	}
@@ -832,6 +1158,10 @@ func takeByTopologyNUMAPacked(topo *topology.CPUTopology, availableCPUs cpuset.C
 	//    a core's-worth of CPUs.
 	//    If `CPUSortingStrategySpread` is specified, skip taking the whole core.
 	if cpuSortingStrategy != CPUSortingStrategySpread {
+		acc.takeRemainCpusForFullCores()
+		if acc.isSatisfied() {
+			return acc.result, nil
+		}
 		acc.takeFullCores()
 		if acc.isSatisfied() {
 			return acc.result, nil
@@ -841,6 +1171,10 @@ func takeByTopologyNUMAPacked(topo *topology.CPUTopology, availableCPUs cpuset.C
 	// 4. Acquire single threads, preferring to fill partially-allocated cores
 	//    on the same sockets as the whole cores we have already taken in this
 	//    allocation.
+	acc.takeRemainingCPUsForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
 	acc.takeRemainingCPUs()
 	if acc.isSatisfied() {
 		return acc.result, nil
@@ -931,7 +1265,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 	}
 
 	// Otherwise build an accumulator to start allocating CPUs from.
-	acc := newCPUAccumulator(topo, availableCPUs, numCPUs, cpuSortingStrategy, reusableCPUsForResize, mustKeepCPUsForScaleDown)
+	acc := newCPUAccumulator(topo, availableCPUs, numCPUs, cpuSortingStrategy, nil, mustKeepCPUsForScaleDown)
 	if acc.isSatisfied() {
 		return acc.result, nil
 	}
@@ -940,11 +1274,23 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 	}
 	// Get the list of NUMA nodes represented by the set of CPUs in 'availableCPUs'.
 	numas := acc.sortAvailableNUMANodes()
+	reusableCPUsForResizeDetail := acc.topo.CPUDetails.KeepOnly(cpuset.New())
+	allocatedCPUsNumber := 0
+	if reusableCPUsForResize != nil {
+		reusableCPUsForResizeDetail = acc.topo.CPUDetails.KeepOnly(*reusableCPUsForResize)
+		allocatedCPUsNumber = reusableCPUsForResize.Size()
+	}
+	allocatedNumas := reusableCPUsForResizeDetail.NUMANodes()
+	allocatedCpuPerNuma := make(mapIntInt, len(numas))
+	for _, numa := range numas {
+		allocatedCpuPerNuma[numa] = reusableCPUsForResizeDetail.CPUsInNUMANodes(numa).Size()
+	}
 
 	// Calculate the minimum and maximum possible number of NUMA nodes that
 	// could satisfy this request. This is used to optimize how many iterations
 	// of the loop we need to go through below.
 	minNUMAs, maxNUMAs := acc.rangeNUMANodesNeededToSatisfy(cpuGroupSize)
+	minNUMAs = max(minNUMAs, allocatedNumas.Size())
 
 	// Try combinations of 1,2,3,... NUMA nodes until we find a combination
 	// where we can evenly distribute CPUs across them. To optimize things, we
@@ -964,10 +1310,16 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 				return Break
 			}
 
+			// Check if the 'allocatedNumas' CPU set is a subset of the 'comboSet'
+			comboSet := cpuset.New(combo...)
+			if !allocatedNumas.IsSubsetOf(comboSet){
+				return Continue
+			}
+
 			// Check that this combination of NUMA nodes has enough CPUs to
 			// satisfy the allocation overall.
 			cpus := acc.details.CPUsInNUMANodes(combo...)
-			if cpus.Size() < numCPUs {
+			if (cpus.Size() + allocatedCPUsNumber) < numCPUs {
 				return Continue
 			}
 
@@ -975,7 +1327,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 			// 'cpuGroupSize' across the NUMA nodes in this combo.
 			numCPUGroups := 0
 			for _, numa := range combo {
-				numCPUGroups += (acc.details.CPUsInNUMANodes(numa).Size() / cpuGroupSize)
+				numCPUGroups += ((acc.details.CPUsInNUMANodes(numa).Size() + allocatedCpuPerNuma[numa]) / cpuGroupSize)
 			}
 			if (numCPUGroups * cpuGroupSize) < numCPUs {
 				return Continue
@@ -987,7 +1339,10 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 			distribution := (numCPUs / len(combo) / cpuGroupSize) * cpuGroupSize
 			for _, numa := range combo {
 				cpus := acc.details.CPUsInNUMANodes(numa)
-				if cpus.Size() < distribution {
+				if (cpus.Size() + allocatedCpuPerNuma[numa]) < distribution {
+					return Continue
+				}
+				if allocatedCpuPerNuma[numa] > distribution {
 					return Continue
 				}
 			}
@@ -1002,7 +1357,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 				availableAfterAllocation[numa] = acc.details.CPUsInNUMANodes(numa).Size()
 			}
 			for _, numa := range combo {
-				availableAfterAllocation[numa] -= distribution
+				availableAfterAllocation[numa] -= (distribution - allocatedCpuPerNuma[numa])
 			}
 
 			// Check if there are any remaining CPUs to distribute across the
@@ -1109,7 +1464,8 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 		// size 'cpuGroupSize' from 'bestCombo'.
 		distribution := (numCPUs / len(bestCombo) / cpuGroupSize) * cpuGroupSize
 		for _, numa := range bestCombo {
-			cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false, reusableCPUsForResize, mustKeepCPUsForScaleDown)
+			reusableCPUsPerNumaForResize := reusableCPUsForResizeDetail.CPUsInNUMANodes(numa)
+			cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false, &reusableCPUsPerNumaForResize, mustKeepCPUsForScaleDown)
 			acc.take(cpus)
 		}
 
@@ -1124,7 +1480,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 				if acc.details.CPUsInNUMANodes(numa).Size() < cpuGroupSize {
 					continue
 				}
-				cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false, reusableCPUsForResize, mustKeepCPUsForScaleDown)
+				cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false, nil, mustKeepCPUsForScaleDown)
 				acc.take(cpus)
 				remainder -= cpuGroupSize
 			}

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1070,6 +1070,474 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 	}
 }
 
+type takeByTopologyTestCaseForResize struct {
+	description   string
+	topo          *topology.CPUTopology
+	opts          StaticPolicyOptions
+	availableCPUs cpuset.CPUSet
+	reusableCPUs  cpuset.CPUSet
+	numCPUs       int
+	expErr        string
+	expResult     cpuset.CPUSet
+}
+
+func commonTakeByTopologyTestCasesForResize(t *testing.T) []takeByTopologyTestCaseForResize {
+	return []takeByTopologyTestCaseForResize{
+		{
+			"Allocated 1 CPUs, and take 1 cpus from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			1,
+			"",
+			cpuset.New(0),
+		},
+		{
+			"Allocated 1 CPU, and take 2 cpu from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			2,
+			"",
+			cpuset.New(0,4),
+		},
+		{
+			"Allocated 1 CPU, and take 2 cpu from single socket with HT, some cpus are taken, no sibling CPU of allocated CPU",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1,3,5,6,7"),
+			cpuset.New(0),
+			2,
+			"",
+			cpuset.New(0,6),
+		},
+		{
+			"Allocated 1 CPU, and take 3 cpu from single socket with HT, some cpus are taken, no sibling CPU of allocated CPU",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1,3,5,6,7"),
+			cpuset.New(0),
+			3,
+			"",
+			cpuset.New(0,1,5),
+		},
+		{
+			"Allocated 1 CPU, and take all cpu from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			8,
+			"",
+			mustParseCPUSet(t, "0-7"),
+		},
+		{
+			"Allocated 1 CPU, take a core from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			2,
+			"",
+			cpuset.New(5,11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			6,
+			"",
+			cpuset.New(1,3,5,7,9,11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus and 1 core of CPU from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			"",
+			cpuset.New(0,1,3,5,6,7,9,11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "20-39,60-79"),
+		},
+		{
+			"Allocated 1 CPU, take a NUMA node of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			20,
+			"",
+			mustParseCPUSet(t, "30-39,70-79"),
+		},
+		{
+			"Allocated 2 CPUs, take a socket and a NUMA node of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-58,60-79"),
+			cpuset.New(39,59),
+			60,
+			"",
+			mustParseCPUSet(t, "0-19,30-59,70-79"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "0-9,20-29,39-48,60-69"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken more CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "9,30-38,49"),
+			cpuset.New(),
+			1,
+			"",
+			mustParseCPUSet(t, "9"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus and 1 CPU from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			41,
+			"",
+			mustParseCPUSet(t, "0-19,39-59"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from single socket with HT, 3 cpus",
+			topoSingleSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-6"),
+			cpuset.New(7),
+			3,
+			"",
+			mustParseCPUSet(t, "0,1,7"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 3 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			3,
+			"",
+			mustParseCPUSet(t, "1,3,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 6 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			6,
+			"",
+			mustParseCPUSet(t, "1,3,5,7,9,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 8 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			"",
+			mustParseCPUSet(t, "0,1,2,3,5,7,9,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket without HT, 2 cpus",
+			topoDualSocketNoHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-6"),
+			cpuset.New(7),
+			2,
+			"",
+			mustParseCPUSet(t, "4,7"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with multi numa per socket and HT, 8 cpus",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			8,
+			"",
+			mustParseCPUSet(t, "20-26,39"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "0-9,20-39,60-69"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from quad socket four way with HT, 12 cpus",
+			topoQuadSocketFourWayHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-59,61-287"),
+			cpuset.New(60),
+			8,
+			"",
+			mustParseCPUSet(t, "3,4,11,12,15,16,23,60"),
+		},
+	}
+}
+
+func TestTakeByTopologyNUMAPackedForResize(t *testing.T) {
+	testCases := commonTakeByTopologyTestCasesForResize(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			strategy := CPUSortingStrategyPacked
+			if tc.opts.DistributeCPUsAcrossCores {
+				strategy = CPUSortingStrategySpread
+			}
+
+			result, err := takeByTopologyNUMAPacked(tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption, &tc.reusableCPUs, nil)
+
+
+			if tc.expErr != "" && err != nil && err.Error() != tc.expErr {
+				t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
+			}
+			if !result.Equals(tc.expResult) {
+				t.Errorf("expected result [%s] to equal [%s]", result, tc.expResult)
+			}
+		})
+	}
+}
+
+type takeByTopologyExtendedTestCaseForResize struct {
+	description   string
+	topo          *topology.CPUTopology
+	availableCPUs cpuset.CPUSet
+	reusableCPUs  cpuset.CPUSet
+	numCPUs       int
+	cpuGroupSize  int
+	expErr        string
+	expResult     cpuset.CPUSet
+}
+
+func commonTakeByTopologyExtendedTestCasesForResize(t *testing.T) []takeByTopologyExtendedTestCaseForResize {
+	return []takeByTopologyExtendedTestCaseForResize{
+		{
+			"Allocated 1 CPUs, allocate 4 full cores with 2 distributed across each NUMA node",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			1,
+			"",
+			mustParseCPUSet(t, "0,6,2,8,1,7,5,11"),
+		},
+		{
+			"Allocated 8 CPUs, allocate 32 full cores with 8 distributed across each NUMA node",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-35,40-75"),
+			mustParseCPUSet(t, "36-39,76-79"),
+			64,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-33,36-39,40-47,50-57,60-67,70-73,76-79"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 8 full cores with 2 distributed across each NUMA node",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2,10-12,20-22,30-32,40-41,50-51,60-61,70-71"),
+			mustParseCPUSet(t, "0,1"),
+			16,
+			1,
+			"",
+			mustParseCPUSet(t, "0-1,10-11,20-21,30-31,40-41,50-51,60-61,70-71"),
+		},
+		{
+			"Allocated 1 CPUs, take 1 cpu from dual socket with HT - core from Socket 0",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			mustParseCPUSet(t, "11"),
+			1,
+			1,
+			"",
+			mustParseCPUSet(t, "11"),
+		},
+		{
+			"Allocated 1 CPUs, take 2 cpu from dual socket with HT - core from Socket 0",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			mustParseCPUSet(t, "11"),
+			2,
+			1,
+			"",
+			mustParseCPUSet(t, "5,11"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 15 CPUs distributed across each NUMA node and 1 CPU spilling over to each of NUMA 0, 1",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-37,40-47,50-57,60-66,70-76"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 14 CPUs distributed across each NUMA node and 2 CPUs spilling over to each of NUMA 0, 1, 2 (cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			2,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-36,40-47,50-57,60-67,70-76"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 15 CPUs distributed across each NUMA node and 1 CPU spilling over to each of NUMA 2, 3 (to keep balance)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-8,10-18,20-39,40-48,50-58,60-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-37,40-46,50-56,60-67,70-77"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 14 CPUs distributed across each NUMA node and 2 CPUs spilling over to each of NUMA 0, 2, 3 (to keep balance with cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-8,10-18,20-39,40-48,50-58,60-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			2,
+			"",
+			mustParseCPUSet(t, "0-7,10-16,20-27,30-37,40-47,50-56,60-67,70-77"),
+		},
+		{
+			"Allocated 4 CPUs, ensure bestRemainder chosen with NUMA nodes that have enough CPUs to satisfy the request",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "10-13,20-23,30-36,40-43,50-53,60-63,70-76"),
+			mustParseCPUSet(t, "0-3"),
+			34,
+			1,
+			"",
+			mustParseCPUSet(t, "0-3,10-13,20-23,30-34,40-43,50-53,60-63,70-74"),
+		},
+		{
+			"Allocated 4 CPUs, ensure previous failure encountered on live machine has been fixed (1/1)",
+			topoDualSocketMultiNumaPerSocketHTLarge,
+			mustParseCPUSet(t, "0,128,30,31,158,159,47,171-175,62,63,190,191,75-79,203-207,94,96,222,223,101-111,229-239,126,127,254,255"),
+			mustParseCPUSet(t, "43-46"),
+			28,
+			1,
+			"",
+			mustParseCPUSet(t, "43-47,75-79,96,101-105,171-174,203-206,229-232"),
+		},
+		{
+			"Allocated 14 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "8-39,48-79"),
+			mustParseCPUSet(t, "0-7,40-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,40-47,50-57,60-67"),
+		},
+		{
+			"Allocated 20 CPUs, allocated CPUs in numa0 is bigger than distribute CPUs, allocated CPUs by takeByTopologyNUMAPacked",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "10-39,50-79"),
+			mustParseCPUSet(t, "0-9,40-49"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "0-23,40-63"),
+		},
+		{
+			"Allocated 12 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes (taking all but 2 from the first NUMA node)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "8-29,32-39,48-69,72-79"),
+			mustParseCPUSet(t, "1-7,41-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "1-8,10-17,20-27,41-48,50-57,60-67"),
+		},
+		{
+			"Allocated 10 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes (even though all 8 could be allocated from the first NUMA node)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-29,31-39,42-69,71-79"),
+			mustParseCPUSet(t, "2-7,42-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "2-9,10-17,20-27,42-49,50-57,60-67"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 13 full cores distributed across the 2 NUMA nodes",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-29,31-69,71-79"),
+			mustParseCPUSet(t, "30,70"),
+			26,
+			1,
+			"",
+			mustParseCPUSet(t, "20-26,30-36,60-65,70-75"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 13 full cores distributed across the 2 NUMA nodes (cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-29,31-69,71-79"),
+			mustParseCPUSet(t, "30,70"),
+			26,
+			2,
+			"",
+			mustParseCPUSet(t, "20-25,30-36,60-65,70-76"),
+		},
+	}
+}
+
+func TestTakeByTopologyNUMADistributedForResize(t *testing.T) {
+	testCases := commonTakeByTopologyExtendedTestCasesForResize(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+
+			result, err := takeByTopologyNUMADistributed(tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, &tc.reusableCPUs, nil)
+			if err != nil {
+				if tc.expErr == "" {
+					t.Errorf("unexpected error [%v]", err)
+				}
+				if tc.expErr != "" && err.Error() != tc.expErr {
+					t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
+				}
+				return
+			}
+			if !result.Equals(tc.expResult) {
+				t.Errorf("expected result [%s] to equal [%s]", result, tc.expResult)
+			}
+		})
+	}
+}
+
 func mustParseCPUSet(t *testing.T, s string) cpuset.CPUSet {
 	cpus, err := cpuset.Parse(s)
 	if err != nil {


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

This PR is based on the https://github.com/esotsal/kubernetes/tree/policy_static.

This PR replace https://github.com/Nordix/kubernetes/pull/8.

What this PR does / why we need it:
When Guaranteed QoS Class Pod scale up and down with Static CPU management policy alongside InPlacePodVerticalScaling, the allocated CPU should meet the kubernetes CPUs allocation rules.

For scaling up, keep the original CPUs, and only allocate the additional number of CPUs. when allocate additional CPUs, it is necessary to ensure that the combination of the original CPUs and the additional CPUs complies with the Kubernetes CPU allocation rules.
For takeByTopologyNUMAPacked：
For example:
Assuming the CPU topology is as follows, and kubernetes CPUs allocation rules is Packed(takeByTopologyNUMAPacked):
image
Allocated CPUs of Pod0 is {2,3}, Allocated CPUs of Pod1 is {13}. Other CPUs are free.
-When scale up of Pod 1 from 1 CPU to 2 CPUs. ==> CPU {12} should to be allocated to Pod1, so CPUset of Pod1 is {12,13}
-When scale up of Pod 1 from 1 CPU to 4 CPUs. ==> CPU {12,14,15} should to be allocated to Pod1, so CPUset of Pod1 is {12,13,14,15}
-When scale up of Pod 1 from 1 CPU to 8 CPUs. ==> CPU {8-12,14,15} should to be allocated to Pod1, so CPUset of Pod1 is {8-15}

For scaling down, if there are mustKeepCPUsForResize, when allocate remained CPUs, it is necessary to ensure that the combination of the mustKeepCPUsForResize CPUs and the allocated remained CPUs complies with the Kubernetes CPU allocation rules.

Which issue(s) this PR fixes:
The step as follows for allocate additional CPUs when scale up with CPU allocated packet(takeByTopologyNUMAPacked) rule, and assume that the NUMA nodes are higher than Sockets in the memory hierarchy.

Keep the original CPUs.
Take remain CPUs in the numa which only allocated CPUs to this Pod. (newly add step)
Take full numa nodes.
Take remain CPUs in the socket which only allocated CPUs to this Pod, than take full sockets in numa nodes which allocated CPUs to this Pod. (newly add step)
Take full sockets.
Take remain CPUs in the physical cores which only allocated CPUs to this Pod, than take full cores in sockets which allocated CPUs to this Pod, than take remain full cores in numa which allocated CPUs to this Pod. (newly add step)
Take full physical cores.
Take remain CPUs in the physical cores which only allocated CPUs to this Pod, than take remain CPUs in sockets which allocated CPUs to this Pod, than take remain CPUs in numa which allocated CPUs to this Pod. (newly add step)
Take remain CPUs
For takeByTopologyNUMADistributed：
The allocated should be a subset of the combo. and the number of allocated CPU is not more than distribute number.

Special notes for your reviewer:
UncoreCaches need to be considerd

Does this PR introduce a user-facing change?
NONE