### PR TITLE
Add some e2e test cases for pod resize

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5655,41 +5655,11 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	var newContainers []core.Container
 	for ix, container := range originalCPUMemPodSpec.Containers {
 		dropCPUMemoryResourcesFromContainer(&container, &oldPod.Spec.Containers[ix])
+		allErrs = append(allErrs, dropMustKeepCPUsEnvFromContainer(&container, &oldPod.Spec.Containers[ix], specPath)...)
 		if !apiequality.Semantic.DeepEqual(container, oldPod.Spec.Containers[ix]) {
 			// This likely means that the user has made changes to resources other than CPU and memory for regular container.
 			errs := field.Forbidden(specPath, "only cpu and memory resources are mutable")
 			allErrs = append(allErrs, errs)
-		}
-
-		// the element named "mustKeepCPUs" in env can be update or add
-		existNewMustKeepCPUs := false
-		existOldMustKeepCPUs := false
-		for jx, newEnv := range container.Env {
-			if newEnv.Name == "mustKeepCPUs" {
-				existNewMustKeepCPUs = true
-				_, err := cpuset.Parse(newEnv.Value)
-				if err != nil {
-					allErrs = append(allErrs, field.Invalid(fldPath, newEnv, "Check mustKeepCPUs format, only number \",\" and \"-\" are allowed"))
-				}
-				// Change mustKeepCPUs
-				for _, oldEnv := range oldPod.Spec.Containers[ix].Env {
-					if oldEnv.Name == "mustKeepCPUs" {
-						existOldMustKeepCPUs = true
-						container.Env[jx] = oldEnv
-						break
-					}
-				}
-				// Add mustKeepCPUs
-				if !existOldMustKeepCPUs && (len(container.Env)-len(oldPod.Spec.Containers[ix].Env)) == 1 {
-					// Delete "mustKeepCPUs" in newPod to make newPod equal to oldPod
-					container.Env = removeEnvVar(container.Env, "mustKeepCPUs")
-				}
-				break
-			}
-		}
-		// Delete mustKeepCPUs
-		if !existNewMustKeepCPUs && (len(oldPod.Spec.Containers[ix].Env)-len(container.Env)) == 1 {
-			oldPod.Spec.Containers[ix].Env = removeEnvVar(oldPod.Spec.Containers[ix].Env, "mustKeepCPUs")
 		}
 		newContainers = append(newContainers, container)
 	}
@@ -5755,6 +5725,42 @@ func dropCPUMemoryResourcesFromContainer(container *core.Container, oldPodSpecCo
 	req := dropCPUMemoryUpdates(container.Resources.Requests, oldPodSpecContainer.Resources.Requests)
 	container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
 	container.ResizePolicy = oldPodSpecContainer.ResizePolicy // +k8s:verify-mutation:reason=clone
+}
+
+// dropMustKeepCPUsEnvFromContainer deletes the "mustKeepCPUs" in env from the container, and copies them from the old pod container resources if present.
+func dropMustKeepCPUsEnvFromContainer(container *core.Container, oldPodSpecContainer *core.Container, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	// the element named "mustKeepCPUs" in env can be update or add
+	existNewMustKeepCPUs := false
+	existOldMustKeepCPUs := false
+	for jx, newEnv := range container.Env {
+		if newEnv.Name == "mustKeepCPUs" {
+			existNewMustKeepCPUs = true
+			_, err := cpuset.Parse(newEnv.Value)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath, newEnv, "Check mustKeepCPUs format, only number \",\" and \"-\" are allowed"))
+			}
+			// Change mustKeepCPUs
+			for _, oldEnv := range oldPodSpecContainer.Env {
+				if oldEnv.Name == "mustKeepCPUs" {
+					existOldMustKeepCPUs = true
+					container.Env[jx] = oldEnv
+					break
+				}
+			}
+			// Add mustKeepCPUs
+			if !existOldMustKeepCPUs && (len(container.Env)-len(oldPodSpecContainer.Env)) == 1 {
+				// Delete "mustKeepCPUs" in newPod to make newPod equal to oldPod
+				container.Env = removeEnvVar(container.Env, "mustKeepCPUs")
+			}
+			break
+		}
+	}
+	// Delete mustKeepCPUs
+	if !existNewMustKeepCPUs && (len(oldPodSpecContainer.Env)-len(container.Env)) == 1 {
+		oldPodSpecContainer.Env = removeEnvVar(oldPodSpecContainer.Env, "mustKeepCPUs")
+	}
+	return allErrs
 }
 
 // isPodResizeRequestSupported checks whether the pod is running on a node with InPlacePodVerticalScaling enabled.

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -26071,22 +26071,22 @@ func TestValidatePodResize(t *testing.T) {
 			err:  "spec: Forbidden: only cpu and memory resources for sidecar containers are mutable",
 		},
 		{
-			test: "Pod env:mustKeepCPUs change value is forbidden",
+			test: "Pod env:mustKeepCPUs change value",
 			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "0"),
 			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
-			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+			err:  "",
 		},
 		{
-			test: "Pod env:mustKeepCPUs add value is forbidden",
+			test: "Pod env:mustKeepCPUs add value",
 			old:  mkPodWith1Env("env1", "a"),
 			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
-			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+			err:  "",
 		},
 		{
-			test: "Pod env:mustKeepCPUs delete is forbidden",
+			test: "Pod env:mustKeepCPUs delete",
 			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
 			new:  mkPodWith1Env("env1", "a"),
-			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+			err:  "",
 		},
 		{
 			test: "Pod env:env1 change is forbidden",
@@ -26105,6 +26105,12 @@ func TestValidatePodResize(t *testing.T) {
 			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
 			new:  mkPodWith1Env("mustKeepCPUs", "0"),
 			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		},
+		{
+			test: "Pod env:mustKeepCPUs delete",
+			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1s2"),
+			err:  "Check mustKeepCPUs format, only number \",\" and \"-\" are allowed",
 		},
 	}
 

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -441,7 +441,7 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 					// Attempt new allocation ( reusing allocated CPUs ) according to the NUMA affinity contained in the hint
 					// Since NUMA affinity container in the hint is unmutable already allocated CPUs pass the criteria
 					mustKeepCPUsForResize := p.GetMustKeepCPUs(container, cpuset)
-					newallocatedcpuset, err := p.allocateCPUs(s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)], &cpusInUseByPodContainerToResize, &mustKeepCPUsForResize)
+					newallocatedcpuset, err := p.allocateCPUs(s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)], &cpusInUseByPodContainerToResize, mustKeepCPUsForResize)
 					if err != nil {
 						klog.ErrorS(err, "Static policy: Unable to allocate new CPUs", "pod", klog.KObj(pod), "containerName", container.Name, "numCPUs", numCPUs)
 						return err
@@ -492,7 +492,7 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 	return nil
 }
 
-func (p *staticPolicy) GetMustKeepCPUs(container *v1.Container, oldCpuset cpuset.CPUSet) cpuset.CPUSet {
+func (p *staticPolicy) GetMustKeepCPUs(container *v1.Container, oldCpuset cpuset.CPUSet) *cpuset.CPUSet {
 	mustKeepCPUs := cpuset.New()
 	for _, envVar := range container.Env {
 		if envVar.Name == "mustKeepCPUs" {
@@ -500,11 +500,24 @@ func (p *staticPolicy) GetMustKeepCPUs(container *v1.Container, oldCpuset cpuset
 			if err == nil && mustKeepCPUsInEnv.Size() != 0 {
 				mustKeepCPUs = oldCpuset.Intersection(mustKeepCPUsInEnv)
 			}
-			break
+			klog.InfoS("mustKeepCPUs ", "is", mustKeepCPUs)
+			if p.options.FullPhysicalCPUsOnly {
+				// mustKeepCPUs must be aligned to the physical core
+				if (mustKeepCPUs.Size() % 2)!= 0 {
+					return nil
+				}
+				mustKeepCPUsDetail := p.topology.CPUDetails.KeepOnly(mustKeepCPUs)
+				mustKeepCPUsDetailCores := mustKeepCPUsDetail.Cores()
+				if (mustKeepCPUs.Size() / mustKeepCPUsDetailCores.Size()) != p.cpuGroupSize {
+					klog.InfoS("mustKeepCPUs is nil")
+					return nil
+				}
+			}
+			return &mustKeepCPUs
 		}
 	}
-	klog.InfoS("mustKeepCPUs:", "is", mustKeepCPUs)
-	return mustKeepCPUs
+	klog.InfoS("mustKeepCPUs is nil")
+	return nil
 }
 
 // getAssignedCPUsOfSiblings returns assigned cpus of given container's siblings(all containers other than the given container) in the given pod `podUID`.

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -311,6 +311,7 @@ func dropNonResizeUpdates(newPod, oldPod *api.Pod) *api.Pod {
 		}
 		pod.Spec.Containers[idx].Resources = ctr.Resources
 		pod.Spec.Containers[idx].ResizePolicy = ctr.ResizePolicy
+		pod.Spec.Containers[idx].Env = ctr.Env
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) {

--- a/test/e2e_node/pod_resize_test.go
+++ b/test/e2e_node/pod_resize_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -1731,4 +1732,739 @@ var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), func
 		doPodResizeErrorTests(policiesAlpha[idp], true, true)
 	}*/
 
+})
+
+func doPodResizeExtendTests(policy cpuManagerPolicyConfig, isInPlacePodVerticalScalingAllocatedStatusEnabled bool, isInPlacePodVerticalScalingExclusiveCPUsEnabled bool) {
+	f := framework.NewDefaultFramework("pod-resize-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var podClient *e2epod.PodClient
+	var oldCfg *kubeletconfig.KubeletConfiguration
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var err error
+		node := getLocalNode(ctx, f)
+		if framework.NodeOSDistroIs("windows") || e2enode.IsARM64(node) {
+			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
+		}
+		if isMultiNUMA() {
+			e2eskipper.Skipf("For simple test, only test one NUMA, multi NUMA -- skipping")
+		}
+		podClient = e2epod.NewPodClient(f)
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	type testCase struct {
+		name                string
+		containers          []e2epod.ResizableContainerInfo
+		patchString         string
+		expected            []e2epod.ResizableContainerInfo
+		addExtendedResource bool
+		skipFlag            bool
+	}
+	
+	setCPUsForTestCase := func(ctx context.Context, tests *testCase, fullPCPUsOnly string){
+		cpuCap, _, _ := getLocalNodeCPUDetails(ctx, f)
+		firstContainerCpuset := cpuset.New()
+		firstAdditionCpuset := cpuset.New()
+		firstExpectedCpuset := cpuset.New()
+		secondContainerCpuset := cpuset.New()
+		secondAdditionCpuset := cpuset.New()
+		secondExpectedCpuset := cpuset.New()
+
+		if (tests.name == "1 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false") {		
+			if cpuCap < 2 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				firstContainerCpuset = cpuset.New(cpuList[1])
+			}
+			tests.containers[0].CPUsAllowedList = fmt.Sprintf("%s", firstContainerCpuset)
+	
+			firstAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				firstAdditionCpuset = cpuset.New(cpuList[0])
+			}
+			firstExpectedCpuset = firstAdditionCpuset.Union(firstContainerCpuset)
+			tests.expected[0].CPUsAllowedList = fmt.Sprintf("%s", firstExpectedCpuset)
+		} else if (tests.name == "1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false") {
+			if cpuCap < 4 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				firstContainerCpuset = cpuset.New(cpuList[1])
+			}
+			tests.containers[0].CPUsAllowedList = fmt.Sprintf("%s", firstContainerCpuset)
+
+			secondContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				secondContainerCpuset = cpuset.New(cpuList[0])
+			}
+			tests.containers[1].CPUsAllowedList = fmt.Sprintf("%s", secondContainerCpuset)
+	
+			firstAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				firstAdditionCpuset = cpuset.New(cpuList[1])
+			}
+			firstExpectedCpuset = firstAdditionCpuset.Union(firstContainerCpuset)
+			tests.expected[0].CPUsAllowedList = fmt.Sprintf("%s", firstExpectedCpuset)
+
+			secondAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(2)).List()
+				secondAdditionCpuset = cpuset.New(cpuList[0])
+			}
+			secondExpectedCpuset = secondAdditionCpuset.Union(secondContainerCpuset)
+			tests.expected[1].CPUsAllowedList = fmt.Sprintf("%s", secondExpectedCpuset)
+		} else if (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = false") || (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false"){
+			if cpuCap < 2 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(2,3)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				if cpuList[1] != 1{
+					firstContainerCpuset = mustParseCPUSet(getCPUSiblingList(1))
+				}
+			}
+			tests.containers[0].CPUsAllowedList = fmt.Sprintf("%s", firstContainerCpuset)
+
+			firstExpectedCpuset = cpuset.New(firstContainerCpuset.List()[0])
+			tests.expected[0].CPUsAllowedList = fmt.Sprintf("%s", firstExpectedCpuset)
+			if(tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false"){
+				startIndex := strings.Index(tests.patchString, `"mustKeepCPUs","value": "`) + len(`"mustKeepCPUs","value": "`)
+				endIndex := strings.Index(tests.patchString[startIndex:], `"`) + startIndex
+				tests.expected[0].CPUsAllowedList = tests.patchString[startIndex:endIndex]
+				ginkgo.By(fmt.Sprintf("startIndex:%d, endIndex:%d", startIndex, endIndex))
+			}
+		} else if (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = true") || (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU with wrong mustKeepCPU, FullPCPUsOnlyOption = ture") || (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true"){
+			if cpuCap < 4 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(2,3,4,5)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				if cpuList[1] != 1{
+					firstContainerCpuset = mustParseCPUSet(getCPUSiblingList(1))
+					firstContainerCpuset = firstContainerCpuset.Union(mustParseCPUSet(getCPUSiblingList(2)))
+				}
+			}
+			tests.containers[0].CPUsAllowedList = fmt.Sprintf("%s", firstContainerCpuset)
+
+			firstExpectedCpuset = mustParseCPUSet(getCPUSiblingList(1))
+			tests.expected[0].CPUsAllowedList = fmt.Sprintf("%s", firstExpectedCpuset)
+			if (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true") {
+				startIndex := strings.Index(tests.patchString, `"mustKeepCPUs","value": "`) + len(`"mustKeepCPUs","value": "`)
+				endIndex := strings.Index(tests.patchString[startIndex:], `"`) + startIndex
+				tests.expected[0].CPUsAllowedList = tests.patchString[startIndex:endIndex]
+				ginkgo.By(fmt.Sprintf("startIndex:%d, endIndex:%d", startIndex, endIndex))
+			}
+		}
+		
+		ginkgo.By(fmt.Sprintf("firstContainerCpuset:%v, firstAdditionCpuset:%v, firstExpectedCpuset:%v", firstContainerCpuset, firstAdditionCpuset, firstExpectedCpuset))
+		ginkgo.By(fmt.Sprintf("secondContainerCpuset:%v, secondAdditionCpuset:%v, secondExpectedCpuset:%v", secondContainerCpuset, secondAdditionCpuset, secondExpectedCpuset))
+	}
+
+	noRestart := v1.NotRequired
+	//doRestart := v1.RestartContainer
+	testsWithFalseFullCPUs := []testCase{
+		{
+			name: "1 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+				{
+					Name:      "c2",
+					Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+                        {"name":"c1",  "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}},
+                        {"name":"c2",  "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+                    ]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+				{
+					Name:      "c2",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"1","memory":"200Mi"},"limits":{"cpu":"1","memory":"200Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "env":[{"name":"mustKeepCPUs","value": "11"}], "resources":{"requests":{"cpu":"1","memory":"400Mi"},"limits":{"cpu":"1","memory":"400Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+		},
+	}
+
+	testsWithTrueFullCPUs := []testCase{
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = true",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "4", CPULim: "4", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "4",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"2","memory":"200Mi"},"limits":{"cpu":"2","memory":"200Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "4", CPULim: "4", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "4",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "env":[{"name":"mustKeepCPUs","value": "2,12"}], "resources":{"requests":{"cpu":"2"},"limits":{"cpu":"2"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		//Abnormal case, CPUs in mustKeepCPUs not full PCPUs, the mustKeepCPUs will be ignored
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU with wrong mustKeepCPU, FullPCPUsOnlyOption = ture",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "4", CPULim: "4", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "4",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "env":[{"name":"mustKeepCPUs","value": "1,2"}], "resources":{"requests":{"cpu":"2"},"limits":{"cpu":"2"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+	}
+
+	timeouts := framework.NewTimeoutContext()
+
+	var tests []testCase
+	if policy.options[cpumanager.FullPCPUsOnlyOption] == "false"{
+		tests = testsWithFalseFullCPUs
+	} else if policy.options[cpumanager.FullPCPUsOnlyOption] == "true"{
+		tests = testsWithTrueFullCPUs
+	}
+
+	for idx := range tests {
+		tc := tests[idx]
+		ginkgo.It(tc.name+policy.title+" (InPlacePodVerticalScalingAllocatedStatus="+strconv.FormatBool(isInPlacePodVerticalScalingAllocatedStatusEnabled)+", InPlacePodVerticalScalingExclusiveCPUs="+strconv.FormatBool(isInPlacePodVerticalScalingExclusiveCPUsEnabled)+")", func(ctx context.Context) {
+			cpuManagerPolicyKubeletConfig(ctx, f, oldCfg, policy.name, policy.options, isInPlacePodVerticalScalingAllocatedStatusEnabled, isInPlacePodVerticalScalingExclusiveCPUsEnabled)
+
+			setCPUsForTestCase(ctx, &tc, policy.options[cpumanager.FullPCPUsOnlyOption])
+			if tc.skipFlag {
+				e2eskipper.Skipf("Skipping CPU Manager tests since the CPU not enough")
+			}
+
+			var testPod, patchedPod *v1.Pod
+			var pErr error
+
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, tc.containers)
+			testPod.GenerateName = "resize-test-"
+			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+			if tc.addExtendedResource {
+				nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+				framework.ExpectNoError(err)
+
+				for _, node := range nodes.Items {
+					addExtendedResource(f.ClientSet, node.Name, fakeExtendedResource, resource.MustParse("123"))
+				}
+				defer func() {
+					for _, node := range nodes.Items {
+						removeExtendedResource(f.ClientSet, node.Name, fakeExtendedResource)
+					}
+				}()
+			}
+
+			ginkgo.By("creating pod")
+			newPod := podClient.CreateSync(ctx, testPod)
+
+			ginkgo.By("verifying initial pod resources, allocations are as expected")
+			e2epod.VerifyPodResources(newPod, tc.containers)
+			ginkgo.By("verifying initial pod resize policy is as expected")
+			e2epod.VerifyPodResizePolicy(newPod, tc.containers)
+
+			ginkgo.By("verifying initial pod status resources are as expected")
+			framework.ExpectNoError(e2epod.VerifyPodStatusResources(newPod, tc.containers))
+			ginkgo.By("verifying initial cgroup config are as expected")
+			framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, newPod, tc.containers))
+			// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+			// machine.
+			// For the moment skip below if CPU Manager Policy is set to none
+			if policy.name == string(cpumanager.PolicyStatic) {
+				ginkgo.By("verifying initial pod Cpus allowed list value")
+				gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+					WithArguments(f, newPod, tc.containers).
+					Should(gomega.BeNil(), "failed to verify initial Pod CPUsAllowedListValue")
+			}
+
+			patchAndVerify := func(patchString string, expectedContainers []e2epod.ResizableContainerInfo, initialContainers []e2epod.ResizableContainerInfo, opStr string, isRollback bool) {
+				ginkgo.By(fmt.Sprintf("patching pod for %s", opStr))
+				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
+					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+				framework.ExpectNoError(pErr, fmt.Sprintf("failed to patch pod for %s", opStr))
+
+				ginkgo.By(fmt.Sprintf("verifying pod patched for %s", opStr))
+				e2epod.VerifyPodResources(patchedPod, expectedContainers)
+
+				ginkgo.By(fmt.Sprintf("waiting for %s to be actuated", opStr))
+				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod)
+				e2epod.ExpectPodResized(ctx, f, resizedPod, expectedContainers)
+
+				// Check cgroup values only for containerd versions before 1.6.9
+				ginkgo.By(fmt.Sprintf("verifying pod container's cgroup values after %s", opStr))
+				framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, resizedPod, expectedContainers))
+
+				ginkgo.By(fmt.Sprintf("verifying pod resources after %s", opStr))
+				e2epod.VerifyPodResources(resizedPod, expectedContainers)
+
+				// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+				// machine.
+				// For the moment skip below if CPU Manager Policy is set to none
+				if policy.name == string(cpumanager.PolicyStatic) {
+					ginkgo.By(fmt.Sprintf("verifying pod Cpus allowed list value after %s", opStr))
+					if isInPlacePodVerticalScalingExclusiveCPUsEnabled {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, expectedContainers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs enabled")
+					} else {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, tc.containers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs disabled (default)")
+					}
+				}
+			}
+
+			ginkgo.By(fmt.Sprintf("First patch"))
+			patchAndVerify(tc.patchString, tc.expected, tc.containers, "resize", false)
+
+			rbPatchStr, err := e2epod.ResizeContainerPatch(tc.containers)
+			framework.ExpectNoError(err)
+			// Resize has been actuated, test rollback
+			ginkgo.By(fmt.Sprintf("Second patch for rollback"))
+			patchAndVerify(rbPatchStr, tc.containers, tc.expected, "rollback", true)
+
+			ginkgo.By("deleting pod")
+			deletePodSyncByName(ctx, f, newPod.Name)
+			// we need to wait for all containers to really be gone so cpumanager reconcile loop will not rewrite the cpu_manager_state.
+			// this is in turn needed because we will have an unavoidable (in the current framework) race with the
+			// reconcile loop which will make our attempt to delete the state file and to restore the old config go haywire
+			waitForAllContainerRemoval(ctx, newPod.Name, newPod.Namespace)
+		})
+	}
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if oldCfg != nil {
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		}
+	})
+
+}
+
+func doMultiPodResizeTests(policy cpuManagerPolicyConfig, isInPlacePodVerticalScalingAllocatedStatusEnabled bool, isInPlacePodVerticalScalingExclusiveCPUsEnabled bool) {
+	f := framework.NewDefaultFramework("pod-resize-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var podClient *e2epod.PodClient
+	var oldCfg *kubeletconfig.KubeletConfiguration
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var err error
+		node := getLocalNode(ctx, f)
+		if framework.NodeOSDistroIs("windows") || e2enode.IsARM64(node) {
+			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
+		}
+		podClient = e2epod.NewPodClient(f)
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	type testPod struct {
+		containers          []e2epod.ResizableContainerInfo
+		patchString         string
+		expected            []e2epod.ResizableContainerInfo
+		addExtendedResource bool
+	}
+
+	type testCase struct {
+		name                string
+		testPod1            testPod
+		testPod2            testPod
+		skipFlag            bool
+	}
+
+	setCPUsForTestCase := func(ctx context.Context, tests *testCase, fullPCPUsOnly string){
+		cpuCap, _, _ := getLocalNodeCPUDetails(ctx, f)
+		firstContainerCpuset := cpuset.New()
+		firstAdditionCpuset := cpuset.New()
+		firstExpectedCpuset := cpuset.New()
+		secondContainerCpuset := cpuset.New()
+		secondAdditionCpuset := cpuset.New()
+		secondExpectedCpuset := cpuset.New()
+
+		if (tests.name == "1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false") {
+			if cpuCap < 4 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				firstContainerCpuset = cpuset.New(cpuList[1])
+			}
+			tests.testPod1.containers[0].CPUsAllowedList = fmt.Sprintf("%s", firstContainerCpuset)
+
+			secondContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				secondContainerCpuset = cpuset.New(cpuList[0])
+			}
+			tests.testPod2.containers[1].CPUsAllowedList = fmt.Sprintf("%s", secondContainerCpuset)
+	
+			firstAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				firstAdditionCpuset = cpuset.New(cpuList[1])
+			}
+			firstExpectedCpuset = firstAdditionCpuset.Union(firstContainerCpuset)
+			tests.testPod1.expected[0].CPUsAllowedList = fmt.Sprintf("%s", firstExpectedCpuset)
+
+			secondAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(2)).List()
+				secondAdditionCpuset = cpuset.New(cpuList[0])
+			}
+			secondExpectedCpuset = secondAdditionCpuset.Union(secondContainerCpuset)
+			tests.testPod2.expected[1].CPUsAllowedList = fmt.Sprintf("%s", secondExpectedCpuset)
+		}
+		ginkgo.By(fmt.Sprintf("firstContainerCpuset:%v, firstAdditionCpuset:%v, firstExpectedCpuset:%v", firstContainerCpuset, firstAdditionCpuset, firstExpectedCpuset))
+		ginkgo.By(fmt.Sprintf("secondContainerCpuset:%v, secondAdditionCpuset:%v, secondExpectedCpuset:%v", secondContainerCpuset, secondAdditionCpuset, secondExpectedCpuset))
+	}
+
+	noRestart := v1.NotRequired
+	tests := []testCase{
+		{
+			name: "2 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false",
+			testPod1: testPod{
+				containers: []e2epod.ResizableContainerInfo{
+					{
+						Name:      "c1",
+						Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+						CPUPolicy: &noRestart,
+						MemPolicy: &noRestart,
+						CPUsAllowedListValue: "1",
+					},
+				},
+				patchString: `{"spec":{"containers":[
+							{"name":"c1", "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+						]}}`,
+				expected: []e2epod.ResizableContainerInfo{
+					{
+						Name:      "c1",
+						Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+						CPUPolicy: &noRestart,
+						MemPolicy: &noRestart,
+						CPUsAllowedListValue: "2",
+					},
+				},
+			},
+			testPod2: testPod{
+				containers: []e2epod.ResizableContainerInfo{
+					{
+						Name:      "c2",
+						Resources: &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+						CPUPolicy: &noRestart,
+						MemPolicy: &noRestart,
+						CPUsAllowedListValue: "1",
+					},
+				},
+				patchString: `{"spec":{"containers":[
+							{"name":"c2", "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+						]}}`,
+				expected: []e2epod.ResizableContainerInfo{
+					{
+						Name:      "c2",
+						Resources: &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+						CPUPolicy: &noRestart,
+						MemPolicy: &noRestart,
+						CPUsAllowedListValue: "2",
+					},
+				},
+			},
+		},
+	}
+
+	timeouts := framework.NewTimeoutContext()
+
+	for idx := range tests {
+		tc := tests[idx]
+		ginkgo.It(tc.name+policy.title+" (InPlacePodVerticalScalingAllocatedStatus="+strconv.FormatBool(isInPlacePodVerticalScalingAllocatedStatusEnabled)+", InPlacePodVerticalScalingExclusiveCPUs="+strconv.FormatBool(isInPlacePodVerticalScalingExclusiveCPUsEnabled)+")", func(ctx context.Context) {
+			cpuManagerPolicyKubeletConfig(ctx, f, oldCfg, policy.name, policy.options, isInPlacePodVerticalScalingAllocatedStatusEnabled, isInPlacePodVerticalScalingExclusiveCPUsEnabled)
+
+			setCPUsForTestCase(ctx, &tc, policy.options[cpumanager.FullPCPUsOnlyOption])
+			if tc.skipFlag {
+				e2eskipper.Skipf("Skipping CPU Manager tests since the CPU not enough")
+			}
+			
+			var patchedPod *v1.Pod
+			var pErr error
+
+			createAndVerify := func(podName string, podClient *e2epod.PodClient, testContainers []e2epod.ResizableContainerInfo) (newPod *v1.Pod) {
+				var testPod *v1.Pod
+	
+				tStamp := strconv.Itoa(time.Now().Nanosecond())
+				testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, fmt.Sprintf("resizepod-%s", podName), tStamp, testContainers)
+				testPod.GenerateName = "resize-test-"
+				testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+	
+				ginkgo.By("creating pod")
+				newPod = podClient.CreateSync(ctx, testPod)
+	
+				ginkgo.By("verifying initial pod resources, allocations are as expected")
+				e2epod.VerifyPodResources(newPod, testContainers)
+				ginkgo.By("verifying initial pod resize policy is as expected")
+				e2epod.VerifyPodResizePolicy(newPod, testContainers)
+	
+				ginkgo.By("verifying initial pod status resources are as expected")
+				framework.ExpectNoError(e2epod.VerifyPodStatusResources(newPod, testContainers))
+				ginkgo.By("verifying initial cgroup config are as expected")
+				framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, newPod, testContainers))
+				// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+				// machine.
+				// For the moment skip below if CPU Manager Policy is set to none
+				if policy.name == string(cpumanager.PolicyStatic) {
+					ginkgo.By("verifying initial pod Cpus allowed list value")
+					gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+						WithArguments(f, newPod, testContainers).
+						Should(gomega.BeNil(), "failed to verify initial Pod CPUsAllowedListValue")
+				}
+				return newPod
+			}
+
+			newPod1 := createAndVerify("testpod1", podClient, tc.testPod1.containers)
+			newPod2 := createAndVerify("testpod2", podClient, tc.testPod2.containers)
+
+			patchAndVerify := func(patchString string, expectedContainers []e2epod.ResizableContainerInfo, initialContainers []e2epod.ResizableContainerInfo, opStr string, isRollback bool, newPod *v1.Pod) {
+				ginkgo.By(fmt.Sprintf("patching pod for %s", opStr))
+				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
+					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+				framework.ExpectNoError(pErr, fmt.Sprintf("failed to patch pod for %s", opStr))
+
+				ginkgo.By(fmt.Sprintf("verifying pod patched for %s", opStr))
+				e2epod.VerifyPodResources(patchedPod, expectedContainers)
+
+				ginkgo.By(fmt.Sprintf("waiting for %s to be actuated", opStr))
+				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod)
+				e2epod.ExpectPodResized(ctx, f, resizedPod, expectedContainers)
+
+				// Check cgroup values only for containerd versions before 1.6.9
+				ginkgo.By(fmt.Sprintf("verifying pod container's cgroup values after %s", opStr))
+				framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, resizedPod, expectedContainers))
+
+				ginkgo.By(fmt.Sprintf("verifying pod resources after %s", opStr))
+				e2epod.VerifyPodResources(resizedPod, expectedContainers)
+
+				// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+				// machine.
+				// For the moment skip below if CPU Manager Policy is set to none
+				if policy.name == string(cpumanager.PolicyStatic) {
+					ginkgo.By(fmt.Sprintf("verifying pod Cpus allowed list value after %s", opStr))
+					if isInPlacePodVerticalScalingExclusiveCPUsEnabled {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, expectedContainers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs enabled")
+					} else {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, initialContainers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs disabled (default)")
+					}
+				}
+			}
+
+			patchAndVerify(tc.testPod1.patchString, tc.testPod1.expected, tc.testPod1.containers, "resize", false, newPod1)
+			patchAndVerify(tc.testPod2.patchString, tc.testPod2.expected, tc.testPod2.containers, "resize", false, newPod2)
+
+			rbPatchStr1, err1 := e2epod.ResizeContainerPatch(tc.testPod1.containers)
+			framework.ExpectNoError(err1)
+			rbPatchStr2, err2 := e2epod.ResizeContainerPatch(tc.testPod2.containers)
+			framework.ExpectNoError(err2)
+			// Resize has been actuated, test rollback
+			patchAndVerify(rbPatchStr1, tc.testPod1.containers, tc.testPod1.expected, "rollback", true, newPod1)
+			patchAndVerify(rbPatchStr2, tc.testPod2.containers, tc.testPod2.expected, "rollback", true, newPod2)
+
+			ginkgo.By("deleting pod")
+			deletePodSyncByName(ctx, f, newPod1.Name)
+			deletePodSyncByName(ctx, f, newPod2.Name)
+			// we need to wait for all containers to really be gone so cpumanager reconcile loop will not rewrite the cpu_manager_state.
+			// this is in turn needed because we will have an unavoidable (in the current framework) race with the
+			// reconcile loop which will make our attempt to delete the state file and to restore the old config go haywire
+			waitForAllContainerRemoval(ctx, newPod1.Name, newPod1.Namespace)
+			waitForAllContainerRemoval(ctx, newPod2.Name, newPod2.Namespace)
+		})
+	}
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if oldCfg != nil {
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		}
+	})
+}
+
+var _ = SIGDescribe("Pod InPlace Resize Container chunxia", framework.WithSerial(), func() {
+
+	policiesGeneralAvailability := []cpuManagerPolicyConfig{
+		{
+			name:  string(cpumanager.PolicyStatic),
+			title: ", alongside CPU Manager Static Policy with no options",
+			options: map[string]string{
+				cpumanager.FullPCPUsOnlyOption:             "false",
+				cpumanager.DistributeCPUsAcrossNUMAOption:  "false",
+				cpumanager.AlignBySocketOption:             "false",
+				cpumanager.DistributeCPUsAcrossCoresOption: "false",
+			},
+		},
+		{
+			name:  string(cpumanager.PolicyStatic),
+			title: ", alongside CPU Manager Static Policy with FullPCPUsOnlyOption",
+			options: map[string]string{
+				cpumanager.FullPCPUsOnlyOption:             "true",
+				cpumanager.DistributeCPUsAcrossNUMAOption:  "false",
+				cpumanager.AlignBySocketOption:             "false",
+				cpumanager.DistributeCPUsAcrossCoresOption: "false",
+			},
+		},
+	}
+
+	doPodResizeExtendTests(policiesGeneralAvailability[0], true, true)
+	doPodResizeExtendTests(policiesGeneralAvailability[1], true, true)
+	doMultiPodResizeTests(policiesGeneralAvailability[0], true, true)
 })


### PR DESCRIPTION
1. Add 7 e2e test cases for pod resize

1 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false
1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false
1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = false
1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false
1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = true
1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true
1 Guaranteed QoS pod, one container - decrease CPU with wrong mustKeepCPU, FullPCPUsOnlyOption = ture
2 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false

Above cases can pass when use 
cpuQuantity := container.Resources.Requests[v1.ResourceCPU] in function guaranteedCPUs() in policy_static.go
The problem is same with https://github.com/kubernetes/kubernetes/pull/123319#discussion_r1888017705

2. Modify the mustKeepCPUs interface code in validation.go, UT case for mustKeepCPUs can pass.
