### PR TITLE
Support InPlacePodVerticalScaling for Static CPU management policy

### DIFF
--- a/pkg/api/pod/testing/make.go
+++ b/pkg/api/pod/testing/make.go
@@ -281,6 +281,12 @@ func SetContainerResources(rr api.ResourceRequirements) TweakContainer {
 	}
 }
 
+func SetContainerEnv(env []api.EnvVar) TweakContainer {
+	return func(cnr *api.Container) {
+		cnr.Env = env
+	}
+}
+
 func SetContainerPorts(ports ...api.ContainerPort) TweakContainer {
 	return func(cnr *api.Container) {
 		cnr.Ports = ports

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
+	"k8s.io/utils/cpuset"
 )
 
 const isNegativeErrorMsg string = apimachineryvalidation.IsNegativeErrorMsg
@@ -5644,6 +5645,7 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	var newContainers []core.Container
 	for ix, container := range originalCPUMemPodSpec.Containers {
 		dropCPUMemoryResourcesFromContainer(&container, &oldPod.Spec.Containers[ix])
+		allErrs = append(allErrs, dropMustKeepCPUsEnvFromContainer(&container, &oldPod.Spec.Containers[ix], specPath)...)
 		if !apiequality.Semantic.DeepEqual(container, oldPod.Spec.Containers[ix]) {
 			// This likely means that the user has made changes to resources other than CPU and memory for regular container.
 			errs := field.Forbidden(specPath, "only cpu and memory resources are mutable")
@@ -5713,6 +5715,52 @@ func dropCPUMemoryResourcesFromContainer(container *core.Container, oldPodSpecCo
 	req := dropCPUMemoryUpdates(container.Resources.Requests, oldPodSpecContainer.Resources.Requests)
 	container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
 	container.ResizePolicy = oldPodSpecContainer.ResizePolicy // +k8s:verify-mutation:reason=clone
+}
+
+func removeEnvVar(envs []core.EnvVar, nameToRemove string) []core.EnvVar {
+	var newEnvs []core.EnvVar
+	for _, env := range envs {
+		if env.Name != nameToRemove {
+			newEnvs = append(newEnvs, env)
+		}
+	}
+	return newEnvs
+}
+
+// dropMustKeepCPUsEnvFromContainer deletes the "mustKeepCPUs" in env from the container, and copies them from the old pod container resources if present.
+func dropMustKeepCPUsEnvFromContainer(container *core.Container, oldPodSpecContainer *core.Container, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	// the element named "mustKeepCPUs" in env can be update or add
+	existNewMustKeepCPUs := false
+	existOldMustKeepCPUs := false
+	for jx, newEnv := range container.Env {
+		if newEnv.Name == "mustKeepCPUs" {
+			existNewMustKeepCPUs = true
+			_, err := cpuset.Parse(newEnv.Value)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath, newEnv, "Check mustKeepCPUs format, only number \",\" and \"-\" are allowed"))
+			}
+			// Change mustKeepCPUs
+			for _, oldEnv := range oldPodSpecContainer.Env {
+				if oldEnv.Name == "mustKeepCPUs" {
+					existOldMustKeepCPUs = true
+					container.Env[jx] = oldEnv
+					break
+				}
+			}
+			// Add mustKeepCPUs
+			if !existOldMustKeepCPUs && (len(container.Env)-len(oldPodSpecContainer.Env)) == 1 {
+				// Delete "mustKeepCPUs" in newPod to make newPod equal to oldPod
+				container.Env = removeEnvVar(container.Env, "mustKeepCPUs")
+			}
+			break
+		}
+	}
+	// Delete mustKeepCPUs
+	if !existNewMustKeepCPUs && (len(oldPodSpecContainer.Env)-len(container.Env)) == 1 {
+		oldPodSpecContainer.Env = removeEnvVar(oldPodSpecContainer.Env, "mustKeepCPUs")
+	}
+	return allErrs
 }
 
 // isPodResizeRequestSupported checks whether the pod is running on a node with InPlacePodVerticalScaling enabled.

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -25639,6 +25639,46 @@ func TestValidatePodResize(t *testing.T) {
 		)...)
 	}
 
+	mkPodWith1Env := func(envName1, envValue1 string, tweaks ...podtest.Tweak) *core.Pod {
+		return podtest.MakePod("pod", append(tweaks,
+			podtest.SetContainers(
+				podtest.MakeContainer(
+					"container",
+					podtest.SetContainerEnv(
+						[]core.EnvVar{
+							{
+								Name:  envName1,
+								Value: envValue1,
+							},
+						},
+					),
+				),
+			),
+		)...)
+	}
+
+	mkPodWith2Env := func(envName1, envValue1, envName2, envValue2 string, tweaks ...podtest.Tweak) *core.Pod {
+		return podtest.MakePod("pod", append(tweaks,
+			podtest.SetContainers(
+				podtest.MakeContainer(
+					"container",
+					podtest.SetContainerEnv(
+						[]core.EnvVar{
+							{
+								Name:  envName1,
+								Value: envValue1,
+							},
+							{
+								Name:  envName2,
+								Value: envValue2,
+							},
+						},
+					),
+				),
+			),
+		)...)
+	}
+
 	tests := []struct {
 		test string
 		old  *core.Pod
@@ -26029,6 +26069,48 @@ func TestValidatePodResize(t *testing.T) {
 			old:  mkPodWithInitContainers(getResources("100m", "0", "1Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways),
 			new:  mkPodWithInitContainers(getResources("100m", "0", "2Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways),
 			err:  "spec: Forbidden: only cpu and memory resources for sidecar containers are mutable",
+		},
+		{
+			test: "Pod env:mustKeepCPUs change value",
+			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "0"),
+			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			err:  "",
+		},
+		{
+			test: "Pod env:mustKeepCPUs add value",
+			old:  mkPodWith1Env("env1", "a"),
+			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			err:  "",
+		},
+		{
+			test: "Pod env:mustKeepCPUs delete",
+			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			new:  mkPodWith1Env("env1", "a"),
+			err:  "",
+		},
+		{
+			test: "Pod env:env1 change is forbidden",
+			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "0"),
+			new:  mkPodWith2Env("env1", "b", "mustKeepCPUs", "0"),
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		},
+		{
+			test: "Pod env:env1 add is forbidden",
+			old:  mkPodWith1Env("mustKeepCPUs", "0"),
+			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		},
+		{
+			test: "Pod env:env1 delete is forbidden",
+			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			new:  mkPodWith1Env("mustKeepCPUs", "0"),
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		},
+		{
+			test: "Pod env:mustKeepCPUs delete",
+			old:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1"),
+			new:  mkPodWith2Env("env1", "a", "mustKeepCPUs", "1s2"),
+			err:  "Check mustKeepCPUs format, only number \",\" and \"-\" are allowed",
 		},
 	}
 

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -95,6 +95,11 @@ type numaOrSocketsFirstFuncs interface {
 	sortAvailableNUMANodes() []int
 	sortAvailableSockets() []int
 	sortAvailableCores() []int
+	takeFullFirstLevelForResize()
+	takeFullSecondLevelForResize()
+	sortAvailableNUMANodesForResize() []int
+	sortAvailableSocketsForResize() []int
+	sortAvailableCoresForResize() []int
 }
 
 type numaFirst struct{ acc *cpuAccumulator }
@@ -204,8 +209,145 @@ func (s *socketsFirst) sortAvailableCores() []int {
 	return result
 }
 
+// If NUMA nodes are higher in the memory hierarchy than sockets, then we take
+// from the set of NUMA Nodes as the first level for resize.
+func (n *numaFirst) takeFullFirstLevelForResize() {
+	n.acc.takeRemainCpusForFullNUMANodes()
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then we take
+// from the set of sockets as the second level for resize.
+func (n *numaFirst) takeFullSecondLevelForResize() {
+	n.acc.takeRemainCpusForFullSockets()
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then return the available NUMA nodes
+// which have allocated CPUs to Container.
+func (n *numaFirst) sortAvailableNUMANodesForResize() []int {
+	allocatedNumaNodesSet := n.acc.resultDetails.NUMANodes()
+	availableNumaNodesSet := n.acc.details.NUMANodes()
+	numas := allocatedNumaNodesSet.Intersection(availableNumaNodesSet).UnsortedList()
+	n.acc.sort(numas, n.acc.details.CPUsInNUMANodes)
+	return numas
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets,
+// Firstly, pull the socket which are allocated CPUs to the Container
+// Secondly, pull the other sockets which are not allocated CPUs to the Container, but contains in the NUMA node which are allocated CPUs to the Container
+func (n *numaFirst) sortAvailableSocketsForResize() []int {
+	var result []int
+
+	// Sort allocated sockets
+	allocatedSocketsSet := n.acc.resultDetails.Sockets()
+	availableSocketsSet := n.acc.details.Sockets()
+	allocatedSockets := allocatedSocketsSet.Intersection(availableSocketsSet).UnsortedList()
+	n.acc.sort(allocatedSockets, n.acc.details.CPUsInSockets)
+	result = append(result, allocatedSockets...)
+
+	// Sort the sockets in allocated numa node, but not allocated CPU on these sockets
+	for _, numa := range n.sortAvailableNUMANodesForResize() {
+		socketSet := n.acc.details.SocketsInNUMANodes(numa)
+		sockets := socketSet.Difference(allocatedSocketsSet).UnsortedList()
+		n.acc.sort(sockets, n.acc.details.CPUsInSockets)
+		result = append(result, sockets...)
+	}
+	return result
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets,
+// Firstly, pull the cores which are allocated CPUs to the Container
+// Secondly, pull the other cores which are not allocated CPUs to the Container, but contains in the NUMA node which are allocated CPUs to the Container
+func (n *numaFirst) sortAvailableCoresForResize() []int {
+	var result []int
+
+	// Sort allocated cores
+	allocatedCoresSet := n.acc.resultDetails.Cores()
+	availableCoresSet := n.acc.details.Cores()
+	allocatedCores := allocatedCoresSet.Intersection(availableCoresSet).UnsortedList()
+	n.acc.sort(allocatedCores, n.acc.details.CPUsInCores)
+	result = append(result, allocatedCores...)
+
+	// Sort the cores in allocated sockets, and allocated numa, but not allocated CPU on these sockets and numa
+	for _, socket := range n.acc.sortAvailableSocketsForResize() {
+		coresSet := n.acc.details.CoresInSockets(socket)
+		cores := coresSet.Difference(allocatedCoresSet).UnsortedList()
+		n.acc.sort(cores, n.acc.details.CPUsInCores)
+		result = append(result, cores...)
+	}
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then we take
+// from the set of NUMA Nodes as the first level for resize.
+func (s *socketsFirst) takeFullFirstLevelForResize() {
+	s.acc.takeRemainCpusForFullSockets()
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then we take
+// from the set of sockets as the second level for resize.
+func (s *socketsFirst) takeFullSecondLevelForResize() {
+	s.acc.takeRemainCpusForFullNUMANodes()
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes,
+// Firstly, pull the NUMA nodes which are allocated CPUs to the Container
+// Secondly, pull the other NUMA nodes which are not allocated CPUs to the Container, but contains in the sockets which are allocated CPUs to the Container
+func (s *socketsFirst) sortAvailableNUMANodesForResize() []int {
+	var result []int
+
+	// Sort allocated sockets
+	allocatedNUMANodesSet := s.acc.resultDetails.NUMANodes()
+	availableNUMANodesSet := s.acc.details.NUMANodes()
+	allocatedNUMANodes := allocatedNUMANodesSet.Intersection(availableNUMANodesSet).UnsortedList()
+	s.acc.sort(allocatedNUMANodes, s.acc.details.CPUsInNUMANodes)
+	result = append(result, allocatedNUMANodes...)
+
+	// Sort the sockets in allocated numa node, but not allocated CPU on these sockets
+	for _, socket := range s.sortAvailableSocketsForResize() {
+		NUMANodesSet := s.acc.details.NUMANodesInSockets(socket)
+		NUMANodes := NUMANodesSet.Difference(allocatedNUMANodesSet).UnsortedList()
+		s.acc.sort(NUMANodes, s.acc.details.CPUsInNUMANodes)
+		result = append(result, NUMANodes...)
+	}
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then return the available sockets
+// which have allocated CPUs to Container.
+func (s *socketsFirst) sortAvailableSocketsForResize() []int {
+	allocatedSocketsSet := s.acc.resultDetails.Sockets()
+	availableSocketsSet := s.acc.details.Sockets()
+	sockets := allocatedSocketsSet.Intersection(availableSocketsSet).UnsortedList()
+	s.acc.sort(sockets, s.acc.details.CPUsInSockets)
+	return sockets
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes,
+// Firstly, pull the cores which are allocated CPUs to the Container
+// Secondly, pull the other cores which are not allocated CPUs to the Container, but contains in the socket which are allocated CPUs to the Container
+func (s *socketsFirst) sortAvailableCoresForResize() []int {
+	var result []int
+
+	// Sort allocated cores
+	allocatedCoresSet := s.acc.resultDetails.Cores()
+	availableCoresSet := s.acc.details.Cores()
+	allocatedCores := allocatedCoresSet.Intersection(availableCoresSet).UnsortedList()
+	s.acc.sort(allocatedCores, s.acc.details.CPUsInCores)
+	result = append(result, allocatedCores...)
+
+	// Sort the cores in allocated sockets, and allocated numa, but not allocated CPU on these sockets and numa
+	for _, NUMANode := range s.acc.sortAvailableNUMANodesForResize() {
+		coresSet := s.acc.details.CoresInNUMANodes(NUMANode)
+		cores := coresSet.Difference(allocatedCoresSet).UnsortedList()
+		s.acc.sort(cores, s.acc.details.CPUsInCores)
+		result = append(result, cores...)
+	}
+	return result
+}
+
 type availableCPUSorter interface {
 	sort() []int
+	sortForResize() []int
 }
 
 type sortCPUsPacked struct{ acc *cpuAccumulator }
@@ -220,6 +362,14 @@ func (s sortCPUsPacked) sort() []int {
 
 func (s sortCPUsSpread) sort() []int {
 	return s.acc.sortAvailableCPUsSpread()
+}
+
+func (s sortCPUsPacked) sortForResize() []int {
+	return s.acc.sortAvailableCPUsPackedForResize()
+}
+
+func (s sortCPUsSpread) sortForResize() []int {
+	return s.acc.sortAvailableCPUsSpreadForResize()
 }
 
 // CPUSortingStrategy describes the CPU sorting solution within the socket scope.
@@ -282,6 +432,9 @@ type cpuAccumulator struct {
 	// cardinality equal to the total number of CPUs to accumulate.
 	result cpuset.CPUSet
 
+	// `resultDetails` is the set of allocated CPUs in `result`
+	resultDetails topology.CPUDetails
+
 	numaOrSocketsFirst numaOrSocketsFirstFuncs
 
 	// availableCPUSorter is used to control the cpu sorting result.
@@ -297,6 +450,7 @@ func newCPUAccumulator(topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, 
 		details:       topo.CPUDetails.KeepOnly(availableCPUs),
 		numCPUsNeeded: numCPUs,
 		result:        cpuset.New(),
+		resultDetails: topo.CPUDetails.KeepOnly(cpuset.New()),
 	}
 
 	if reusableCPUsForResize != nil {
@@ -422,6 +576,21 @@ func (a *cpuAccumulator) freeCores() []int {
 // Returns free CPU IDs as a slice sorted by sortAvailableCPUsPacked().
 func (a *cpuAccumulator) freeCPUs() []int {
 	return a.availableCPUSorter.sort()
+}
+
+// Return true if this numa only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullNUMANodeForResize(numaID int) bool {
+	return a.resultDetails.CPUsInNUMANodes(numaID).Size()+a.details.CPUsInNUMANodes(numaID).Size() == a.topo.CPUDetails.CPUsInNUMANodes(numaID).Size()
+}
+
+// Return true if this Socket only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullSocketForResize(socketID int) bool {
+	return a.resultDetails.CPUsInSockets(socketID).Size()+a.details.CPUsInSockets(socketID).Size() == a.topo.CPUsPerSocket()
+}
+
+// return true if this Socket only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullCoreForResize(coreID int) bool {
+	return a.resultDetails.CPUsInCores(coreID).Size()+a.details.CPUsInCores(coreID).Size() == a.topo.CPUsPerCore()
 }
 
 // Sorts the provided list of NUMA nodes/sockets/cores/cpus referenced in 'ids'
@@ -553,8 +722,108 @@ func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 	return result
 }
 
+// Sort all NUMA nodes with at least one free CPU.
+//
+// If NUMA nodes are higher than sockets in the memory hierarchy, they are sorted by ascending number
+// of free CPUs that they contain. "higher than sockets in the memory hierarchy" means that NUMA nodes
+// contain a bigger number of CPUs (free and busy) than sockets, or equivalently that each NUMA node
+// contains more than one socket.
+//
+// If instead NUMA nodes are lower in the memory hierarchy than sockets, they are sorted as follows.
+// First part, sort the NUMA nodes which contains the CPUs allocated to Container. and these NUMA nodes
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the NUMA nodes contained in the sockets which contains the CPUs allocated to Container,
+// but exclude the NUMA nodes in first part. these NUMA nodes sorted by the rule as below
+//
+//	First, they are sorted by number of free CPUs in the sockets that contain them. Then, for each
+//	socket they are sorted by number of free CPUs that they contain. The order is always ascending.
+func (a *cpuAccumulator) sortAvailableNUMANodesForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableNUMANodesForResize()
+}
+
+// Sort all sockets with at least one free CPU.
+//
+// If sockets are higher than NUMA nodes in the memory hierarchy, they are sorted by ascending number
+// of free CPUs that they contain. "higher than NUMA nodes in the memory hierarchy" means that
+// sockets contain a bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each
+// socket contains more than one NUMA node.
+//
+// If instead sockets are lower in the memory hierarchy than NUMA nodes, they are sorted as follows.
+// First part, sort the sockets which contains the CPUs allocated to Container. and these sockets
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the sockets contained in the NUMA nodes which contains the CPUs allocated to Container,
+// but exclude the sockets in first part. these sockets sorted by the rule as below
+//
+//	First, they are sorted by number of free CPUs in the NUMA nodes that contain them. Then, for each
+//	NUMA node they are sorted by number of free CPUs that they contain. The order is always ascending.
+func (a *cpuAccumulator) sortAvailableSocketsForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableSocketsForResize()
+}
+
+// Sort all cores with at least one free CPU.
+//
+// If sockets are higher in the memory hierarchy than NUMA nodes, meaning that sockets contain a
+// bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each socket contains
+// more than one NUMA node, the cores are sorted as follows.
+// First part, sort the cores which contains the CPUs allocated to Container. and these cores
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the cores contained in the NUMA nodes which contains the CPUs allocated to Container,
+// but exclude the cores in first part. these cores sorted by the rule as below
+// First, they are sorted by number of
+// free CPUs that their sockets contain. Then, for each socket, the cores in it are sorted by number
+// of free CPUs that their NUMA nodes contain. Then, for each NUMA node, the cores in it are sorted
+// by number of free CPUs that they contain. The order is always ascending.
+
+// If instead NUMA nodes are higher in the memory hierarchy than sockets, the sorting happens in the
+// same way as described in the previous paragraph.
+func (a *cpuAccumulator) sortAvailableCoresForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableCoresForResize()
+}
+
+// Sort all free CPUs.
+//
+// If sockets are higher in the memory hierarchy than NUMA nodes, meaning that sockets contain a
+// bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each socket contains
+// more than one NUMA node, the CPUs are sorted as follows.
+// First part, sort the cores which contains the CPUs allocated to Container. and these cores
+// are sorted by number of free CPUs that they contain. for each core, the CPUs in it are
+// sorted by numerical ID.
+// Second part, sort the cores contained in the NUMA nodes which contains the CPUs allocated to Container,
+// but exclude the cores in first part. these cores sorted by the rule as below
+// First, they are sorted by number of
+// free CPUs that their sockets contain. Then, for each socket, the CPUs in it are sorted by number
+// of free CPUs that their NUMA nodes contain. Then, for each NUMA node, the CPUs in it are sorted
+// by number of free CPUs that their cores contain. Finally, for each core, the CPUs in it are
+// sorted by numerical ID. The order is always ascending.
+//
+// If instead NUMA nodes are higher in the memory hierarchy than sockets, the sorting happens in the
+// same way as described in the previous paragraph.
+func (a *cpuAccumulator) sortAvailableCPUsPackedForResize() []int {
+	var result []int
+	for _, core := range a.sortAvailableCoresForResize() {
+		cpus := a.details.CPUsInCores(core).UnsortedList()
+		sort.Ints(cpus)
+		result = append(result, cpus...)
+	}
+	return result
+}
+
+// Sort all available CPUs:
+// - First by core using sortAvailableSocketsForResize().
+// - Then within each socket, sort cpus directly using the sort() algorithm defined above.
+func (a *cpuAccumulator) sortAvailableCPUsSpreadForResize() []int {
+	var result []int
+	for _, socket := range a.sortAvailableSocketsForResize() {
+		cpus := a.details.CPUsInSockets(socket).UnsortedList()
+		sort.Ints(cpus)
+		result = append(result, cpus...)
+	}
+	return result
+}
+
 func (a *cpuAccumulator) take(cpus cpuset.CPUSet) {
 	a.result = a.result.Union(cpus)
+	a.resultDetails = a.topo.CPUDetails.KeepOnly(a.result)
 	a.details = a.details.KeepOnly(a.details.CPUs().Difference(a.result))
 	a.numCPUsNeeded -= cpus.Size()
 }
@@ -651,6 +920,55 @@ func (a *cpuAccumulator) takeFullCores() {
 func (a *cpuAccumulator) takeRemainingCPUs() {
 	for _, cpu := range a.availableCPUSorter.sort() {
 		klog.V(4).InfoS("takeRemainingCPUs: claiming CPU", "cpu", cpu)
+		a.take(cpuset.New(cpu))
+		if a.isSatisfied() {
+			return
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeRemainCpusForFullNUMANodes() {
+	for _, numa := range a.sortAvailableNUMANodesForResize() {
+		if a.isFullNUMANodeForResize(numa) {
+			cpusInNUMANode := a.details.CPUsInNUMANodes(numa)
+			if !a.needsAtLeast(cpusInNUMANode.Size()) {
+				continue
+			}
+			klog.V(4).InfoS("takeRemainCpusForFullNUMANodes: claiming NUMA node", "numa", numa, "cpusInNUMANode", cpusInNUMANode)
+			a.take(cpusInNUMANode)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeRemainCpusForFullSockets() {
+	for _, socket := range a.sortAvailableSocketsForResize() {
+		if a.isFullSocketForResize(socket) {
+			cpusInSocket := a.details.CPUsInSockets(socket)
+			if !a.needsAtLeast(cpusInSocket.Size()) {
+				continue
+			}
+			klog.V(4).InfoS("takeRemainCpusForFullSockets: claiming Socket", "socket", socket, "cpusInSocket", cpusInSocket)
+			a.take(cpusInSocket)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeRemainCpusForFullCores() {
+	for _, core := range a.sortAvailableCoresForResize() {
+		if a.isFullCoreForResize(core) {
+			cpusInCore := a.details.CPUsInCores(core)
+			if !a.needsAtLeast(cpusInCore.Size()) {
+				continue
+			}
+			klog.V(4).InfoS("takeRemainCpusForFullCores: claiming Core", "core", core, "cpusInCore", cpusInCore)
+			a.take(cpusInCore)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeRemainingCPUsForResize() {
+	for _, cpu := range a.availableCPUSorter.sortForResize() {
+		klog.V(4).InfoS("takeRemainingCPUsForResize: claiming CPU", "cpu", cpu)
 		a.take(cpuset.New(cpu))
 		if a.isSatisfied() {
 			return
@@ -806,7 +1124,15 @@ func takeByTopologyNUMAPacked(topo *topology.CPUTopology, availableCPUs cpuset.C
 	//    requires at least a NUMA node or socket's-worth of CPUs. If NUMA
 	//    Nodes map to 1 or more sockets, pull from NUMA nodes first.
 	//    Otherwise pull from sockets first.
+	acc.numaOrSocketsFirst.takeFullFirstLevelForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
 	acc.numaOrSocketsFirst.takeFullFirstLevel()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+	acc.numaOrSocketsFirst.takeFullSecondLevelForResize()
 	if acc.isSatisfied() {
 		return acc.result, nil
 	}
@@ -829,6 +1155,10 @@ func takeByTopologyNUMAPacked(topo *topology.CPUTopology, availableCPUs cpuset.C
 	//    a core's-worth of CPUs.
 	//    If `CPUSortingStrategySpread` is specified, skip taking the whole core.
 	if cpuSortingStrategy != CPUSortingStrategySpread {
+		acc.takeRemainCpusForFullCores()
+		if acc.isSatisfied() {
+			return acc.result, nil
+		}
 		acc.takeFullCores()
 		if acc.isSatisfied() {
 			return acc.result, nil
@@ -838,6 +1168,10 @@ func takeByTopologyNUMAPacked(topo *topology.CPUTopology, availableCPUs cpuset.C
 	// 4. Acquire single threads, preferring to fill partially-allocated cores
 	//    on the same sockets as the whole cores we have already taken in this
 	//    allocation.
+	acc.takeRemainingCPUsForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
 	acc.takeRemainingCPUs()
 	if acc.isSatisfied() {
 		return acc.result, nil
@@ -928,7 +1262,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 	}
 
 	// Otherwise build an accumulator to start allocating CPUs from.
-	acc := newCPUAccumulator(topo, availableCPUs, numCPUs, cpuSortingStrategy, reusableCPUsForResize, mustKeepCPUsForScaleDown)
+	acc := newCPUAccumulator(topo, availableCPUs, numCPUs, cpuSortingStrategy, nil, mustKeepCPUsForScaleDown)
 	if acc.isSatisfied() {
 		return acc.result, nil
 	}
@@ -937,11 +1271,23 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 	}
 	// Get the list of NUMA nodes represented by the set of CPUs in 'availableCPUs'.
 	numas := acc.sortAvailableNUMANodes()
+	reusableCPUsForResizeDetail := acc.topo.CPUDetails.KeepOnly(cpuset.New())
+	allocatedCPUsNumber := 0
+	if reusableCPUsForResize != nil {
+		reusableCPUsForResizeDetail = acc.topo.CPUDetails.KeepOnly(*reusableCPUsForResize)
+		allocatedCPUsNumber = reusableCPUsForResize.Size()
+	}
+	allocatedNumas := reusableCPUsForResizeDetail.NUMANodes()
+	allocatedCPUPerNuma := make(mapIntInt, len(numas))
+	for _, numa := range numas {
+		allocatedCPUPerNuma[numa] = reusableCPUsForResizeDetail.CPUsInNUMANodes(numa).Size()
+	}
 
 	// Calculate the minimum and maximum possible number of NUMA nodes that
 	// could satisfy this request. This is used to optimize how many iterations
 	// of the loop we need to go through below.
 	minNUMAs, maxNUMAs := acc.rangeNUMANodesNeededToSatisfy(cpuGroupSize)
+	minNUMAs = max(minNUMAs, allocatedNumas.Size())
 
 	// Try combinations of 1,2,3,... NUMA nodes until we find a combination
 	// where we can evenly distribute CPUs across them. To optimize things, we
@@ -961,10 +1307,16 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 				return Break
 			}
 
+			// Check if the 'allocatedNumas' CPU set is a subset of the 'comboSet'
+			comboSet := cpuset.New(combo...)
+			if !allocatedNumas.IsSubsetOf(comboSet) {
+				return Continue
+			}
+
 			// Check that this combination of NUMA nodes has enough CPUs to
 			// satisfy the allocation overall.
 			cpus := acc.details.CPUsInNUMANodes(combo...)
-			if cpus.Size() < numCPUs {
+			if (cpus.Size() + allocatedCPUsNumber) < numCPUs {
 				return Continue
 			}
 
@@ -972,7 +1324,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 			// 'cpuGroupSize' across the NUMA nodes in this combo.
 			numCPUGroups := 0
 			for _, numa := range combo {
-				numCPUGroups += (acc.details.CPUsInNUMANodes(numa).Size() / cpuGroupSize)
+				numCPUGroups += ((acc.details.CPUsInNUMANodes(numa).Size() + allocatedCPUPerNuma[numa]) / cpuGroupSize)
 			}
 			if (numCPUGroups * cpuGroupSize) < numCPUs {
 				return Continue
@@ -984,7 +1336,10 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 			distribution := (numCPUs / len(combo) / cpuGroupSize) * cpuGroupSize
 			for _, numa := range combo {
 				cpus := acc.details.CPUsInNUMANodes(numa)
-				if cpus.Size() < distribution {
+				if (cpus.Size() + allocatedCPUPerNuma[numa]) < distribution {
+					return Continue
+				}
+				if allocatedCPUPerNuma[numa] > distribution {
 					return Continue
 				}
 			}
@@ -999,7 +1354,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 				availableAfterAllocation[numa] = acc.details.CPUsInNUMANodes(numa).Size()
 			}
 			for _, numa := range combo {
-				availableAfterAllocation[numa] -= distribution
+				availableAfterAllocation[numa] -= (distribution - allocatedCPUPerNuma[numa])
 			}
 
 			// Check if there are any remaining CPUs to distribute across the
@@ -1106,7 +1461,8 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 		// size 'cpuGroupSize' from 'bestCombo'.
 		distribution := (numCPUs / len(bestCombo) / cpuGroupSize) * cpuGroupSize
 		for _, numa := range bestCombo {
-			cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false, reusableCPUsForResize, mustKeepCPUsForScaleDown)
+			reusableCPUsPerNumaForResize := reusableCPUsForResizeDetail.CPUsInNUMANodes(numa)
+			cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false, &reusableCPUsPerNumaForResize, mustKeepCPUsForScaleDown)
 			acc.take(cpus)
 		}
 
@@ -1121,7 +1477,7 @@ func takeByTopologyNUMADistributed(topo *topology.CPUTopology, availableCPUs cpu
 				if acc.details.CPUsInNUMANodes(numa).Size() < cpuGroupSize {
 					continue
 				}
-				cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false, reusableCPUsForResize, mustKeepCPUsForScaleDown)
+				cpus, _ := takeByTopologyNUMAPacked(acc.topo, acc.details.CPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false, nil, mustKeepCPUsForScaleDown)
 				acc.take(cpus)
 				remainder -= cpuGroupSize
 			}

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1070,6 +1070,473 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 	}
 }
 
+type takeByTopologyTestCaseForResize struct {
+	description   string
+	topo          *topology.CPUTopology
+	opts          StaticPolicyOptions
+	availableCPUs cpuset.CPUSet
+	reusableCPUs  cpuset.CPUSet
+	numCPUs       int
+	expErr        string
+	expResult     cpuset.CPUSet
+}
+
+func commonTakeByTopologyTestCasesForResize(t *testing.T) []takeByTopologyTestCaseForResize {
+	return []takeByTopologyTestCaseForResize{
+		{
+			"Allocated 1 CPUs, and take 1 cpus from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			1,
+			"",
+			cpuset.New(0),
+		},
+		{
+			"Allocated 1 CPU, and take 2 cpu from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			2,
+			"",
+			cpuset.New(0, 4),
+		},
+		{
+			"Allocated 1 CPU, and take 2 cpu from single socket with HT, some cpus are taken, no sibling CPU of allocated CPU",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1,3,5,6,7"),
+			cpuset.New(0),
+			2,
+			"",
+			cpuset.New(0, 6),
+		},
+		{
+			"Allocated 1 CPU, and take 3 cpu from single socket with HT, some cpus are taken, no sibling CPU of allocated CPU",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1,3,5,6,7"),
+			cpuset.New(0),
+			3,
+			"",
+			cpuset.New(0, 1, 5),
+		},
+		{
+			"Allocated 1 CPU, and take all cpu from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			8,
+			"",
+			mustParseCPUSet(t, "0-7"),
+		},
+		{
+			"Allocated 1 CPU, take a core from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			2,
+			"",
+			cpuset.New(5, 11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			6,
+			"",
+			cpuset.New(1, 3, 5, 7, 9, 11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus and 1 core of CPU from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			"",
+			cpuset.New(0, 1, 3, 5, 6, 7, 9, 11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "20-39,60-79"),
+		},
+		{
+			"Allocated 1 CPU, take a NUMA node of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			20,
+			"",
+			mustParseCPUSet(t, "30-39,70-79"),
+		},
+		{
+			"Allocated 2 CPUs, take a socket and a NUMA node of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-58,60-79"),
+			cpuset.New(39, 59),
+			60,
+			"",
+			mustParseCPUSet(t, "0-19,30-59,70-79"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "0-9,20-29,39-48,60-69"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken more CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "9,30-38,49"),
+			cpuset.New(),
+			1,
+			"",
+			mustParseCPUSet(t, "9"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus and 1 CPU from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			41,
+			"",
+			mustParseCPUSet(t, "0-19,39-59"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from single socket with HT, 3 cpus",
+			topoSingleSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-6"),
+			cpuset.New(7),
+			3,
+			"",
+			mustParseCPUSet(t, "0,1,7"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 3 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			3,
+			"",
+			mustParseCPUSet(t, "1,3,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 6 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			6,
+			"",
+			mustParseCPUSet(t, "1,3,5,7,9,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 8 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			"",
+			mustParseCPUSet(t, "0,1,2,3,5,7,9,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket without HT, 2 cpus",
+			topoDualSocketNoHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-6"),
+			cpuset.New(7),
+			2,
+			"",
+			mustParseCPUSet(t, "4,7"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with multi numa per socket and HT, 8 cpus",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			8,
+			"",
+			mustParseCPUSet(t, "20-26,39"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "0-9,20-39,60-69"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from quad socket four way with HT, 12 cpus",
+			topoQuadSocketFourWayHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-59,61-287"),
+			cpuset.New(60),
+			8,
+			"",
+			mustParseCPUSet(t, "3,4,11,12,15,16,23,60"),
+		},
+	}
+}
+
+func TestTakeByTopologyNUMAPackedForResize(t *testing.T) {
+	testCases := commonTakeByTopologyTestCasesForResize(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			strategy := CPUSortingStrategyPacked
+			if tc.opts.DistributeCPUsAcrossCores {
+				strategy = CPUSortingStrategySpread
+			}
+
+			result, err := takeByTopologyNUMAPacked(tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption, &tc.reusableCPUs, nil)
+
+			if tc.expErr != "" && err != nil && err.Error() != tc.expErr {
+				t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
+			}
+			if !result.Equals(tc.expResult) {
+				t.Errorf("expected result [%s] to equal [%s]", result, tc.expResult)
+			}
+		})
+	}
+}
+
+type takeByTopologyExtendedTestCaseForResize struct {
+	description   string
+	topo          *topology.CPUTopology
+	availableCPUs cpuset.CPUSet
+	reusableCPUs  cpuset.CPUSet
+	numCPUs       int
+	cpuGroupSize  int
+	expErr        string
+	expResult     cpuset.CPUSet
+}
+
+func commonTakeByTopologyExtendedTestCasesForResize(t *testing.T) []takeByTopologyExtendedTestCaseForResize {
+	return []takeByTopologyExtendedTestCaseForResize{
+		{
+			"Allocated 1 CPUs, allocate 4 full cores with 2 distributed across each NUMA node",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			1,
+			"",
+			mustParseCPUSet(t, "0,6,2,8,1,7,5,11"),
+		},
+		{
+			"Allocated 8 CPUs, allocate 32 full cores with 8 distributed across each NUMA node",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-35,40-75"),
+			mustParseCPUSet(t, "36-39,76-79"),
+			64,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-33,36-39,40-47,50-57,60-67,70-73,76-79"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 8 full cores with 2 distributed across each NUMA node",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2,10-12,20-22,30-32,40-41,50-51,60-61,70-71"),
+			mustParseCPUSet(t, "0,1"),
+			16,
+			1,
+			"",
+			mustParseCPUSet(t, "0-1,10-11,20-21,30-31,40-41,50-51,60-61,70-71"),
+		},
+		{
+			"Allocated 1 CPUs, take 1 cpu from dual socket with HT - core from Socket 0",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			mustParseCPUSet(t, "11"),
+			1,
+			1,
+			"",
+			mustParseCPUSet(t, "11"),
+		},
+		{
+			"Allocated 1 CPUs, take 2 cpu from dual socket with HT - core from Socket 0",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			mustParseCPUSet(t, "11"),
+			2,
+			1,
+			"",
+			mustParseCPUSet(t, "5,11"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 15 CPUs distributed across each NUMA node and 1 CPU spilling over to each of NUMA 0, 1",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-37,40-47,50-57,60-66,70-76"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 14 CPUs distributed across each NUMA node and 2 CPUs spilling over to each of NUMA 0, 1, 2 (cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			2,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-36,40-47,50-57,60-67,70-76"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 15 CPUs distributed across each NUMA node and 1 CPU spilling over to each of NUMA 2, 3 (to keep balance)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-8,10-18,20-39,40-48,50-58,60-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-37,40-46,50-56,60-67,70-77"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 14 CPUs distributed across each NUMA node and 2 CPUs spilling over to each of NUMA 0, 2, 3 (to keep balance with cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-8,10-18,20-39,40-48,50-58,60-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			2,
+			"",
+			mustParseCPUSet(t, "0-7,10-16,20-27,30-37,40-47,50-56,60-67,70-77"),
+		},
+		{
+			"Allocated 4 CPUs, ensure bestRemainder chosen with NUMA nodes that have enough CPUs to satisfy the request",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "10-13,20-23,30-36,40-43,50-53,60-63,70-76"),
+			mustParseCPUSet(t, "0-3"),
+			34,
+			1,
+			"",
+			mustParseCPUSet(t, "0-3,10-13,20-23,30-34,40-43,50-53,60-63,70-74"),
+		},
+		{
+			"Allocated 4 CPUs, ensure previous failure encountered on live machine has been fixed (1/1)",
+			topoDualSocketMultiNumaPerSocketHTLarge,
+			mustParseCPUSet(t, "0,128,30,31,158,159,47,171-175,62,63,190,191,75-79,203-207,94,96,222,223,101-111,229-239,126,127,254,255"),
+			mustParseCPUSet(t, "43-46"),
+			28,
+			1,
+			"",
+			mustParseCPUSet(t, "43-47,75-79,96,101-105,171-174,203-206,229-232"),
+		},
+		{
+			"Allocated 14 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "8-39,48-79"),
+			mustParseCPUSet(t, "0-7,40-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,40-47,50-57,60-67"),
+		},
+		{
+			"Allocated 20 CPUs, allocated CPUs in numa0 is bigger than distribute CPUs, allocated CPUs by takeByTopologyNUMAPacked",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "10-39,50-79"),
+			mustParseCPUSet(t, "0-9,40-49"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "0-23,40-63"),
+		},
+		{
+			"Allocated 12 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes (taking all but 2 from the first NUMA node)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "8-29,32-39,48-69,72-79"),
+			mustParseCPUSet(t, "1-7,41-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "1-8,10-17,20-27,41-48,50-57,60-67"),
+		},
+		{
+			"Allocated 10 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes (even though all 8 could be allocated from the first NUMA node)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-29,31-39,42-69,71-79"),
+			mustParseCPUSet(t, "2-7,42-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "2-9,10-17,20-27,42-49,50-57,60-67"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 13 full cores distributed across the 2 NUMA nodes",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-29,31-69,71-79"),
+			mustParseCPUSet(t, "30,70"),
+			26,
+			1,
+			"",
+			mustParseCPUSet(t, "20-26,30-36,60-65,70-75"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 13 full cores distributed across the 2 NUMA nodes (cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-29,31-69,71-79"),
+			mustParseCPUSet(t, "30,70"),
+			26,
+			2,
+			"",
+			mustParseCPUSet(t, "20-25,30-36,60-65,70-76"),
+		},
+	}
+}
+
+func TestTakeByTopologyNUMADistributedForResize(t *testing.T) {
+	testCases := commonTakeByTopologyExtendedTestCasesForResize(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+
+			result, err := takeByTopologyNUMADistributed(tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, &tc.reusableCPUs, nil)
+			if err != nil {
+				if tc.expErr == "" {
+					t.Errorf("unexpected error [%v]", err)
+				}
+				if tc.expErr != "" && err.Error() != tc.expErr {
+					t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
+				}
+				return
+			}
+			if !result.Equals(tc.expResult) {
+				t.Errorf("expected result [%s] to equal [%s]", result, tc.expResult)
+			}
+		})
+	}
+}
+
 func mustParseCPUSet(t *testing.T, s string) cpuset.CPUSet {
 	cpus, err := cpuset.Parse(s)
 	if err != nil {

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -440,7 +440,8 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 					klog.InfoS("Topology Affinity", "pod", klog.KObj(pod), "containerName", container.Name, "affinity", hint)
 					// Attempt new allocation ( reusing allocated CPUs ) according to the NUMA affinity contained in the hint
 					// Since NUMA affinity container in the hint is unmutable already allocated CPUs pass the criteria
-					newallocatedcpuset, err := p.allocateCPUs(s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)], &cpusInUseByPodContainerToResize, nil)
+					mustKeepCPUsForResize := p.GetMustKeepCPUs(container, cpuset)
+					newallocatedcpuset, err := p.allocateCPUs(s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)], &cpusInUseByPodContainerToResize, mustKeepCPUsForResize)
 					if err != nil {
 						klog.ErrorS(err, "Static policy: Unable to allocate new CPUs", "pod", klog.KObj(pod), "containerName", container.Name, "numCPUs", numCPUs)
 						return err
@@ -489,6 +490,34 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 	p.updateMetricsOnAllocate(cpuset)
 
 	klog.V(4).InfoS("Allocated exclusive CPUs", "pod", klog.KObj(pod), "containerName", container.Name, "cpuset", cpuset)
+	return nil
+}
+
+func (p *staticPolicy) GetMustKeepCPUs(container *v1.Container, oldCpuset cpuset.CPUSet) *cpuset.CPUSet {
+	mustKeepCPUs := cpuset.New()
+	for _, envVar := range container.Env {
+		if envVar.Name == "mustKeepCPUs" {
+			mustKeepCPUsInEnv, err := cpuset.Parse(envVar.Value)
+			if err == nil && mustKeepCPUsInEnv.Size() != 0 {
+				mustKeepCPUs = oldCpuset.Intersection(mustKeepCPUsInEnv)
+			}
+			klog.InfoS("mustKeepCPUs ", "is", mustKeepCPUs)
+			if p.options.FullPhysicalCPUsOnly {
+				// mustKeepCPUs must be aligned to the physical core
+				if (mustKeepCPUs.Size() % 2) != 0 {
+					return nil
+				}
+				mustKeepCPUsDetail := p.topology.CPUDetails.KeepOnly(mustKeepCPUs)
+				mustKeepCPUsDetailCores := mustKeepCPUsDetail.Cores()
+				if (mustKeepCPUs.Size() / mustKeepCPUsDetailCores.Size()) != p.cpuGroupSize {
+					klog.InfoS("mustKeepCPUs is nil")
+					return nil
+				}
+			}
+			return &mustKeepCPUs
+		}
+	}
+	klog.InfoS("mustKeepCPUs is nil")
 	return nil
 }
 

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -312,6 +312,7 @@ func dropNonResizeUpdates(newPod, oldPod *api.Pod) *api.Pod {
 		}
 		pod.Spec.Containers[idx].Resources = ctr.Resources
 		pod.Spec.Containers[idx].ResizePolicy = ctr.ResizePolicy
+		pod.Spec.Containers[idx].Env = ctr.Env
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) {

--- a/test/e2e_node/pod_resize_test.go
+++ b/test/e2e_node/pod_resize_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"strconv"
 	"time"
 
@@ -1731,4 +1732,737 @@ var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), func
 		doPodResizeErrorTests(policiesAlpha[idp], true, true)
 	}*/
 
+})
+
+func doPodResizeExtendTests(policy cpuManagerPolicyConfig, isInPlacePodVerticalScalingAllocatedStatusEnabled bool, isInPlacePodVerticalScalingExclusiveCPUsEnabled bool) {
+	f := framework.NewDefaultFramework("pod-resize-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var podClient *e2epod.PodClient
+	var oldCfg *kubeletconfig.KubeletConfiguration
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var err error
+		node := getLocalNode(ctx, f)
+		if framework.NodeOSDistroIs("windows") || e2enode.IsARM64(node) {
+			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
+		}
+		if isMultiNUMA() {
+			e2eskipper.Skipf("For simple test, only test one NUMA, multi NUMA -- skipping")
+		}
+		podClient = e2epod.NewPodClient(f)
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	type testCase struct {
+		name                string
+		containers          []e2epod.ResizableContainerInfo
+		patchString         string
+		expected            []e2epod.ResizableContainerInfo
+		addExtendedResource bool
+		skipFlag            bool
+	}
+
+	setCPUsForTestCase := func(ctx context.Context, tests *testCase, fullPCPUsOnly string) {
+		cpuCap, _, _ := getLocalNodeCPUDetails(ctx, f)
+		firstContainerCpuset := cpuset.New()
+		firstAdditionCpuset := cpuset.New()
+		firstExpectedCpuset := cpuset.New()
+		secondContainerCpuset := cpuset.New()
+		secondAdditionCpuset := cpuset.New()
+		secondExpectedCpuset := cpuset.New()
+
+		if tests.name == "1 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false" {
+			if cpuCap < 2 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				firstContainerCpuset = cpuset.New(cpuList[1])
+			}
+			tests.containers[0].CPUsAllowedList = firstContainerCpuset.String()
+
+			firstAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				firstAdditionCpuset = cpuset.New(cpuList[0])
+			}
+			firstExpectedCpuset = firstAdditionCpuset.Union(firstContainerCpuset)
+			tests.expected[0].CPUsAllowedList = firstExpectedCpuset.String()
+		} else if tests.name == "1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false" {
+			if cpuCap < 4 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				firstContainerCpuset = cpuset.New(cpuList[1])
+			}
+			tests.containers[0].CPUsAllowedList = firstContainerCpuset.String()
+
+			secondContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				secondContainerCpuset = cpuset.New(cpuList[0])
+			}
+			tests.containers[1].CPUsAllowedList = secondContainerCpuset.String()
+
+			firstAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				firstAdditionCpuset = cpuset.New(cpuList[1])
+			}
+			firstExpectedCpuset = firstAdditionCpuset.Union(firstContainerCpuset)
+			tests.expected[0].CPUsAllowedList = firstExpectedCpuset.String()
+
+			secondAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(2)).List()
+				secondAdditionCpuset = cpuset.New(cpuList[0])
+			}
+			secondExpectedCpuset = secondAdditionCpuset.Union(secondContainerCpuset)
+			tests.expected[1].CPUsAllowedList = secondExpectedCpuset.String()
+		} else if (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = false") || (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false") {
+			if cpuCap < 2 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(2, 3)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				if cpuList[1] != 1 {
+					firstContainerCpuset = mustParseCPUSet(getCPUSiblingList(1))
+				}
+			}
+			tests.containers[0].CPUsAllowedList = firstContainerCpuset.String()
+
+			firstExpectedCpuset = cpuset.New(firstContainerCpuset.List()[0])
+			tests.expected[0].CPUsAllowedList = firstExpectedCpuset.String()
+			if tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false" {
+				startIndex := strings.Index(tests.patchString, `"mustKeepCPUs","value": "`) + len(`"mustKeepCPUs","value": "`)
+				endIndex := strings.Index(tests.patchString[startIndex:], `"`) + startIndex
+				tests.expected[0].CPUsAllowedList = tests.patchString[startIndex:endIndex]
+				ginkgo.By(fmt.Sprintf("startIndex:%d, endIndex:%d", startIndex, endIndex))
+			}
+		} else if (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = true") || (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU with wrong mustKeepCPU, FullPCPUsOnlyOption = ture") || (tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true") {
+			if cpuCap < 4 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(2, 3, 4, 5)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				if cpuList[1] != 1 {
+					firstContainerCpuset = mustParseCPUSet(getCPUSiblingList(1))
+					firstContainerCpuset = firstContainerCpuset.Union(mustParseCPUSet(getCPUSiblingList(2)))
+				}
+			}
+			tests.containers[0].CPUsAllowedList = firstContainerCpuset.String()
+
+			firstExpectedCpuset = mustParseCPUSet(getCPUSiblingList(1))
+			tests.expected[0].CPUsAllowedList = firstExpectedCpuset.String()
+			if tests.name == "1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true" {
+				startIndex := strings.Index(tests.patchString, `"mustKeepCPUs","value": "`) + len(`"mustKeepCPUs","value": "`)
+				endIndex := strings.Index(tests.patchString[startIndex:], `"`) + startIndex
+				tests.expected[0].CPUsAllowedList = tests.patchString[startIndex:endIndex]
+				ginkgo.By(fmt.Sprintf("startIndex:%d, endIndex:%d", startIndex, endIndex))
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("firstContainerCpuset:%v, firstAdditionCpuset:%v, firstExpectedCpuset:%v", firstContainerCpuset, firstAdditionCpuset, firstExpectedCpuset))
+		ginkgo.By(fmt.Sprintf("secondContainerCpuset:%v, secondAdditionCpuset:%v, secondExpectedCpuset:%v", secondContainerCpuset, secondAdditionCpuset, secondExpectedCpuset))
+	}
+
+	noRestart := v1.NotRequired
+	testsWithFalseFullCPUs := []testCase{
+		{
+			name: "1 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+				{
+					Name:                 "c2",
+					Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+                        {"name":"c1",  "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}},
+                        {"name":"c2",  "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+                    ]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+				{
+					Name:                 "c2",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"1","memory":"200Mi"},"limits":{"cpu":"1","memory":"200Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory with mustKeepCPUs, FullPCPUsOnlyOption = false",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "env":[{"name":"mustKeepCPUs","value": "11"}], "resources":{"requests":{"cpu":"1","memory":"400Mi"},"limits":{"cpu":"1","memory":"400Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "1",
+				},
+			},
+		},
+	}
+
+	testsWithTrueFullCPUs := []testCase{
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory, FullPCPUsOnlyOption = true",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "4", CPULim: "4", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "4",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"2","memory":"200Mi"},"limits":{"cpu":"2","memory":"200Mi"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU & memory with correct mustKeepCPU, FullPCPUsOnlyOption = true",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "4", CPULim: "4", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "4",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "env":[{"name":"mustKeepCPUs","value": "2,12"}], "resources":{"requests":{"cpu":"2"},"limits":{"cpu":"2"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+		// Abnormal case, CPUs in mustKeepCPUs not full PCPUs, the mustKeepCPUs will be ignored
+		{
+			name: "1 Guaranteed QoS pod, one container - decrease CPU with wrong mustKeepCPU, FullPCPUsOnlyOption = ture",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "4", CPULim: "4", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "4",
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "env":[{"name":"mustKeepCPUs","value": "1,2"}], "resources":{"requests":{"cpu":"2"},"limits":{"cpu":"2"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:                 "c1",
+					Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy:            &noRestart,
+					MemPolicy:            &noRestart,
+					CPUsAllowedListValue: "2",
+				},
+			},
+		},
+	}
+
+	timeouts := framework.NewTimeoutContext()
+
+	var tests []testCase
+	if policy.options[cpumanager.FullPCPUsOnlyOption] == "false" {
+		tests = testsWithFalseFullCPUs
+	} else if policy.options[cpumanager.FullPCPUsOnlyOption] == "true" {
+		tests = testsWithTrueFullCPUs
+	}
+
+	for idx := range tests {
+		tc := tests[idx]
+		ginkgo.It(tc.name+policy.title+" (InPlacePodVerticalScalingAllocatedStatus="+strconv.FormatBool(isInPlacePodVerticalScalingAllocatedStatusEnabled)+", InPlacePodVerticalScalingExclusiveCPUs="+strconv.FormatBool(isInPlacePodVerticalScalingExclusiveCPUsEnabled)+")", func(ctx context.Context) {
+			cpuManagerPolicyKubeletConfig(ctx, f, oldCfg, policy.name, policy.options, isInPlacePodVerticalScalingAllocatedStatusEnabled, isInPlacePodVerticalScalingExclusiveCPUsEnabled)
+
+			setCPUsForTestCase(ctx, &tc, policy.options[cpumanager.FullPCPUsOnlyOption])
+			if tc.skipFlag {
+				e2eskipper.Skipf("Skipping CPU Manager tests since the CPU not enough")
+			}
+
+			var testPod, patchedPod *v1.Pod
+			var pErr error
+
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, tc.containers)
+			testPod.GenerateName = "resize-test-"
+			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+			if tc.addExtendedResource {
+				nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+				framework.ExpectNoError(err)
+
+				for _, node := range nodes.Items {
+					addExtendedResource(f.ClientSet, node.Name, fakeExtendedResource, resource.MustParse("123"))
+				}
+				defer func() {
+					for _, node := range nodes.Items {
+						removeExtendedResource(f.ClientSet, node.Name, fakeExtendedResource)
+					}
+				}()
+			}
+
+			ginkgo.By("creating pod")
+			newPod := podClient.CreateSync(ctx, testPod)
+
+			ginkgo.By("verifying initial pod resources, allocations are as expected")
+			e2epod.VerifyPodResources(newPod, tc.containers)
+			ginkgo.By("verifying initial pod resize policy is as expected")
+			e2epod.VerifyPodResizePolicy(newPod, tc.containers)
+
+			ginkgo.By("verifying initial pod status resources are as expected")
+			framework.ExpectNoError(e2epod.VerifyPodStatusResources(newPod, tc.containers))
+			ginkgo.By("verifying initial cgroup config are as expected")
+			framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, newPod, tc.containers))
+			// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+			// machine.
+			// For the moment skip below if CPU Manager Policy is set to none
+			if policy.name == string(cpumanager.PolicyStatic) {
+				ginkgo.By("verifying initial pod Cpus allowed list value")
+				gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+					WithArguments(f, newPod, tc.containers).
+					Should(gomega.BeNil(), "failed to verify initial Pod CPUsAllowedListValue")
+			}
+
+			patchAndVerify := func(patchString string, expectedContainers []e2epod.ResizableContainerInfo, initialContainers []e2epod.ResizableContainerInfo, opStr string, isRollback bool) {
+				ginkgo.By(fmt.Sprintf("patching pod for %s", opStr))
+				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
+					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+				framework.ExpectNoError(pErr, fmt.Sprintf("failed to patch pod for %s", opStr))
+
+				ginkgo.By(fmt.Sprintf("verifying pod patched for %s", opStr))
+				e2epod.VerifyPodResources(patchedPod, expectedContainers)
+
+				ginkgo.By(fmt.Sprintf("waiting for %s to be actuated", opStr))
+				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod)
+				e2epod.ExpectPodResized(ctx, f, resizedPod, expectedContainers)
+
+				// Check cgroup values only for containerd versions before 1.6.9
+				ginkgo.By(fmt.Sprintf("verifying pod container's cgroup values after %s", opStr))
+				framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, resizedPod, expectedContainers))
+
+				ginkgo.By(fmt.Sprintf("verifying pod resources after %s", opStr))
+				e2epod.VerifyPodResources(resizedPod, expectedContainers)
+
+				// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+				// machine.
+				// For the moment skip below if CPU Manager Policy is set to none
+				if policy.name == string(cpumanager.PolicyStatic) {
+					ginkgo.By(fmt.Sprintf("verifying pod Cpus allowed list value after %s", opStr))
+					if isInPlacePodVerticalScalingExclusiveCPUsEnabled {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, expectedContainers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs enabled")
+					} else {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, tc.containers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs disabled (default)")
+					}
+				}
+			}
+
+			ginkgo.By("First patch")
+			patchAndVerify(tc.patchString, tc.expected, tc.containers, "resize", false)
+
+			rbPatchStr, err := e2epod.ResizeContainerPatch(tc.containers)
+			framework.ExpectNoError(err)
+			// Resize has been actuated, test rollback
+			ginkgo.By("Second patch for rollback")
+			patchAndVerify(rbPatchStr, tc.containers, tc.expected, "rollback", true)
+
+			ginkgo.By("deleting pod")
+			deletePodSyncByName(ctx, f, newPod.Name)
+			// we need to wait for all containers to really be gone so cpumanager reconcile loop will not rewrite the cpu_manager_state.
+			// this is in turn needed because we will have an unavoidable (in the current framework) race with the
+			// reconcile loop which will make our attempt to delete the state file and to restore the old config go haywire
+			waitForAllContainerRemoval(ctx, newPod.Name, newPod.Namespace)
+		})
+	}
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if oldCfg != nil {
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		}
+	})
+
+}
+
+func doMultiPodResizeTests(policy cpuManagerPolicyConfig, isInPlacePodVerticalScalingAllocatedStatusEnabled bool, isInPlacePodVerticalScalingExclusiveCPUsEnabled bool) {
+	f := framework.NewDefaultFramework("pod-resize-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var podClient *e2epod.PodClient
+	var oldCfg *kubeletconfig.KubeletConfiguration
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var err error
+		node := getLocalNode(ctx, f)
+		if framework.NodeOSDistroIs("windows") || e2enode.IsARM64(node) {
+			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
+		}
+		podClient = e2epod.NewPodClient(f)
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	type testPod struct {
+		containers  []e2epod.ResizableContainerInfo
+		patchString string
+		expected    []e2epod.ResizableContainerInfo
+	}
+
+	type testCase struct {
+		name     string
+		testPod1 testPod
+		testPod2 testPod
+		skipFlag bool
+	}
+
+	setCPUsForTestCase := func(ctx context.Context, tests *testCase, fullPCPUsOnly string) {
+		cpuCap, _, _ := getLocalNodeCPUDetails(ctx, f)
+		firstContainerCpuset := cpuset.New()
+		firstAdditionCpuset := cpuset.New()
+		firstExpectedCpuset := cpuset.New()
+		secondContainerCpuset := cpuset.New()
+		secondAdditionCpuset := cpuset.New()
+		secondExpectedCpuset := cpuset.New()
+
+		if tests.name == "1 Guaranteed QoS pod, two containers - increase CPU & memory, FullPCPUsOnlyOption = false" {
+			if cpuCap < 4 {
+				tests.skipFlag = true
+			}
+			firstContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(0)).List()
+				firstContainerCpuset = cpuset.New(cpuList[1])
+			}
+			tests.testPod1.containers[0].CPUsAllowedList = firstContainerCpuset.String()
+
+			secondContainerCpuset = cpuset.New(1)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				secondContainerCpuset = cpuset.New(cpuList[0])
+			}
+			tests.testPod2.containers[1].CPUsAllowedList = secondContainerCpuset.String()
+
+			firstAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(1)).List()
+				firstAdditionCpuset = cpuset.New(cpuList[1])
+			}
+			firstExpectedCpuset = firstAdditionCpuset.Union(firstContainerCpuset)
+			tests.testPod1.expected[0].CPUsAllowedList = firstExpectedCpuset.String()
+
+			secondAdditionCpuset = cpuset.New(2)
+			if isHTEnabled() {
+				cpuList := mustParseCPUSet(getCPUSiblingList(2)).List()
+				secondAdditionCpuset = cpuset.New(cpuList[0])
+			}
+			secondExpectedCpuset = secondAdditionCpuset.Union(secondContainerCpuset)
+			tests.testPod2.expected[1].CPUsAllowedList = secondExpectedCpuset.String()
+		}
+		ginkgo.By(fmt.Sprintf("firstContainerCpuset:%v, firstAdditionCpuset:%v, firstExpectedCpuset:%v", firstContainerCpuset, firstAdditionCpuset, firstExpectedCpuset))
+		ginkgo.By(fmt.Sprintf("secondContainerCpuset:%v, secondAdditionCpuset:%v, secondExpectedCpuset:%v", secondContainerCpuset, secondAdditionCpuset, secondExpectedCpuset))
+	}
+
+	noRestart := v1.NotRequired
+	tests := []testCase{
+		{
+			name: "2 Guaranteed QoS pod, one container - increase CPU & memory, FullPCPUsOnlyOption = false",
+			testPod1: testPod{
+				containers: []e2epod.ResizableContainerInfo{
+					{
+						Name:                 "c1",
+						Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+						CPUPolicy:            &noRestart,
+						MemPolicy:            &noRestart,
+						CPUsAllowedListValue: "1",
+					},
+				},
+				patchString: `{"spec":{"containers":[
+							{"name":"c1", "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+						]}}`,
+				expected: []e2epod.ResizableContainerInfo{
+					{
+						Name:                 "c1",
+						Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+						CPUPolicy:            &noRestart,
+						MemPolicy:            &noRestart,
+						CPUsAllowedListValue: "2",
+					},
+				},
+			},
+			testPod2: testPod{
+				containers: []e2epod.ResizableContainerInfo{
+					{
+						Name:                 "c2",
+						Resources:            &e2epod.ContainerResources{CPUReq: "1", CPULim: "1", MemReq: "200Mi", MemLim: "200Mi"},
+						CPUPolicy:            &noRestart,
+						MemPolicy:            &noRestart,
+						CPUsAllowedListValue: "1",
+					},
+				},
+				patchString: `{"spec":{"containers":[
+							{"name":"c2", "resources":{"requests":{"cpu":"2","memory":"400Mi"},"limits":{"cpu":"2","memory":"400Mi"}}}
+						]}}`,
+				expected: []e2epod.ResizableContainerInfo{
+					{
+						Name:                 "c2",
+						Resources:            &e2epod.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "400Mi", MemLim: "400Mi"},
+						CPUPolicy:            &noRestart,
+						MemPolicy:            &noRestart,
+						CPUsAllowedListValue: "2",
+					},
+				},
+			},
+		},
+	}
+
+	timeouts := framework.NewTimeoutContext()
+
+	for idx := range tests {
+		tc := tests[idx]
+		ginkgo.It(tc.name+policy.title+" (InPlacePodVerticalScalingAllocatedStatus="+strconv.FormatBool(isInPlacePodVerticalScalingAllocatedStatusEnabled)+", InPlacePodVerticalScalingExclusiveCPUs="+strconv.FormatBool(isInPlacePodVerticalScalingExclusiveCPUsEnabled)+")", func(ctx context.Context) {
+			cpuManagerPolicyKubeletConfig(ctx, f, oldCfg, policy.name, policy.options, isInPlacePodVerticalScalingAllocatedStatusEnabled, isInPlacePodVerticalScalingExclusiveCPUsEnabled)
+
+			setCPUsForTestCase(ctx, &tc, policy.options[cpumanager.FullPCPUsOnlyOption])
+			if tc.skipFlag {
+				e2eskipper.Skipf("Skipping CPU Manager tests since the CPU not enough")
+			}
+
+			var patchedPod *v1.Pod
+			var pErr error
+
+			createAndVerify := func(podName string, podClient *e2epod.PodClient, testContainers []e2epod.ResizableContainerInfo) (newPod *v1.Pod) {
+				var testPod *v1.Pod
+
+				tStamp := strconv.Itoa(time.Now().Nanosecond())
+				testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, fmt.Sprintf("resizepod-%s", podName), tStamp, testContainers)
+				testPod.GenerateName = "resize-test-"
+				testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+				ginkgo.By("creating pod")
+				newPod = podClient.CreateSync(ctx, testPod)
+
+				ginkgo.By("verifying initial pod resources, allocations are as expected")
+				e2epod.VerifyPodResources(newPod, testContainers)
+				ginkgo.By("verifying initial pod resize policy is as expected")
+				e2epod.VerifyPodResizePolicy(newPod, testContainers)
+
+				ginkgo.By("verifying initial pod status resources are as expected")
+				framework.ExpectNoError(e2epod.VerifyPodStatusResources(newPod, testContainers))
+				ginkgo.By("verifying initial cgroup config are as expected")
+				framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, newPod, testContainers))
+				// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+				// machine.
+				// For the moment skip below if CPU Manager Policy is set to none
+				if policy.name == string(cpumanager.PolicyStatic) {
+					ginkgo.By("verifying initial pod Cpus allowed list value")
+					gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+						WithArguments(f, newPod, testContainers).
+						Should(gomega.BeNil(), "failed to verify initial Pod CPUsAllowedListValue")
+				}
+				return newPod
+			}
+
+			newPod1 := createAndVerify("testpod1", podClient, tc.testPod1.containers)
+			newPod2 := createAndVerify("testpod2", podClient, tc.testPod2.containers)
+
+			patchAndVerify := func(patchString string, expectedContainers []e2epod.ResizableContainerInfo, initialContainers []e2epod.ResizableContainerInfo, opStr string, isRollback bool, newPod *v1.Pod) {
+				ginkgo.By(fmt.Sprintf("patching pod for %s", opStr))
+				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
+					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+				framework.ExpectNoError(pErr, fmt.Sprintf("failed to patch pod for %s", opStr))
+
+				ginkgo.By(fmt.Sprintf("verifying pod patched for %s", opStr))
+				e2epod.VerifyPodResources(patchedPod, expectedContainers)
+
+				ginkgo.By(fmt.Sprintf("waiting for %s to be actuated", opStr))
+				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod)
+				e2epod.ExpectPodResized(ctx, f, resizedPod, expectedContainers)
+
+				// Check cgroup values only for containerd versions before 1.6.9
+				ginkgo.By(fmt.Sprintf("verifying pod container's cgroup values after %s", opStr))
+				framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, resizedPod, expectedContainers))
+
+				ginkgo.By(fmt.Sprintf("verifying pod resources after %s", opStr))
+				e2epod.VerifyPodResources(resizedPod, expectedContainers)
+
+				// TODO make this dynamic depending on Policy Name, Resources input and topology of target
+				// machine.
+				// For the moment skip below if CPU Manager Policy is set to none
+				if policy.name == string(cpumanager.PolicyStatic) {
+					ginkgo.By(fmt.Sprintf("verifying pod Cpus allowed list value after %s", opStr))
+					if isInPlacePodVerticalScalingExclusiveCPUsEnabled {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, expectedContainers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs enabled")
+					} else {
+						gomega.Eventually(ctx, e2epod.VerifyPodContainersCPUsAllowedListValue, timeouts.PodStartShort, timeouts.Poll).
+							WithArguments(f, resizedPod, initialContainers).
+							Should(gomega.BeNil(), "failed to verify Pod CPUsAllowedListValue for resizedPod with InPlacePodVerticalScalingExclusiveCPUs disabled (default)")
+					}
+				}
+			}
+
+			patchAndVerify(tc.testPod1.patchString, tc.testPod1.expected, tc.testPod1.containers, "resize", false, newPod1)
+			patchAndVerify(tc.testPod2.patchString, tc.testPod2.expected, tc.testPod2.containers, "resize", false, newPod2)
+
+			rbPatchStr1, err1 := e2epod.ResizeContainerPatch(tc.testPod1.containers)
+			framework.ExpectNoError(err1)
+			rbPatchStr2, err2 := e2epod.ResizeContainerPatch(tc.testPod2.containers)
+			framework.ExpectNoError(err2)
+			// Resize has been actuated, test rollback
+			patchAndVerify(rbPatchStr1, tc.testPod1.containers, tc.testPod1.expected, "rollback", true, newPod1)
+			patchAndVerify(rbPatchStr2, tc.testPod2.containers, tc.testPod2.expected, "rollback", true, newPod2)
+
+			ginkgo.By("deleting pod")
+			deletePodSyncByName(ctx, f, newPod1.Name)
+			deletePodSyncByName(ctx, f, newPod2.Name)
+			// we need to wait for all containers to really be gone so cpumanager reconcile loop will not rewrite the cpu_manager_state.
+			// this is in turn needed because we will have an unavoidable (in the current framework) race with the
+			// reconcile loop which will make our attempt to delete the state file and to restore the old config go haywire
+			waitForAllContainerRemoval(ctx, newPod1.Name, newPod1.Namespace)
+			waitForAllContainerRemoval(ctx, newPod2.Name, newPod2.Namespace)
+		})
+	}
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if oldCfg != nil {
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		}
+	})
+}
+
+var _ = SIGDescribe("Pod InPlace Resize Container Extended Cases", framework.WithSerial(), func() {
+
+	policiesGeneralAvailability := []cpuManagerPolicyConfig{
+		{
+			name:  string(cpumanager.PolicyStatic),
+			title: ", alongside CPU Manager Static Policy with no options",
+			options: map[string]string{
+				cpumanager.FullPCPUsOnlyOption:             "false",
+				cpumanager.DistributeCPUsAcrossNUMAOption:  "false",
+				cpumanager.AlignBySocketOption:             "false",
+				cpumanager.DistributeCPUsAcrossCoresOption: "false",
+			},
+		},
+		{
+			name:  string(cpumanager.PolicyStatic),
+			title: ", alongside CPU Manager Static Policy with FullPCPUsOnlyOption",
+			options: map[string]string{
+				cpumanager.FullPCPUsOnlyOption:             "true",
+				cpumanager.DistributeCPUsAcrossNUMAOption:  "false",
+				cpumanager.AlignBySocketOption:             "false",
+				cpumanager.DistributeCPUsAcrossCoresOption: "false",
+			},
+		},
+	}
+
+	doPodResizeExtendTests(policiesGeneralAvailability[0], true, true)
+	doPodResizeExtendTests(policiesGeneralAvailability[1], true, true)
+	doMultiPodResizeTests(policiesGeneralAvailability[0], true, true)
 })


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

This PR is based on the https://github.com/esotsal/kubernetes/tree/policy_static.

What this PR does / why we need it:
**1. A proposal for CPU allocated strategy when Pod scale up and down**

When Guaranteed QoS Class Pod scale up and down with Static CPU management policy alongside InPlacePodVerticalScaling, 
and additional CPUs are allocated, it is necessary to ensure that the combination of the retained CPUs and the additional CPUs complies with the Kubernetes CPU allocation strategy. 

Based on the KEP#5554, for scale-up, the retained CPUs are the previous "resized CPUs," and for scale-down, the retained CPUs are the "original CPUs."

There are two CPU allocation strategies:

- **NUMA Packed**: Retained CPUs and newly allocated CPUs should be as close as possible (same NUMA, same socket, same UnCoreCache, same core).

For example:
Assuming the CPU topology is as follows, and kubernetes CPUs allocation rules is Packed(takeByTopologyNUMAPacked):
![image](https://github.com/user-attachments/assets/afe03b0a-a5ab-4452-9eb8-6552d613afc0)

Allocated CPUs of Pod0 is {2,3}, Allocated CPUs of Pod1 is {13}. Other CPUs are free.
-When scale up of Pod 1 from 1 CPU to 2 CPUs. ==> CPU {12} should to be allocated to Pod1, so CPUset of Pod1 is {12,13}
-When scale up of Pod 1 from 1 CPU to 4 CPUs. ==> CPU {12,14,15} should to be allocated to Pod1, so CPUset of Pod1 is {12,13,14,15}
-When scale up of Pod 1 from 1 CPU to 8 CPUs. ==> CPU {8-12,14,15} should to be allocated to Pod1, so CPUset of Pod1 is {8-15}

Detail design (assuming that the NUMA nodes are higher than Sockets in the memory hierarchy, code modified in takeByTopologyNUMAPacked):

1. Keep the retained CPUs.
2. Take remain CPUs in the numa which has only allocated CPUs to this container. (newly add function **takeFullFirstLevelForResize**)
3. Take full numa nodes.
4. Take remain CPUs in the socket which has only allocated CPUs to this container, then take full sockets in numa nodes which allocated CPUs to this container. (newly add function **takeFullSecondLevelForResize**)
5. Take full sockets.
6. Take remain CPUs in the UncoreCache which only allocated CPUs to this container. then take full UncoreCache in numa node which allocated CPUs to this container.(**takeRemainCpusForUncoreCache** (Not implemented, because the Uncore Cache feature was not available when we submitted the code))
7. Take full UncoreCaches.
8. Take remain CPUs in the physical cores which only allocated CPUs to this container, then take full cores in sockets which allocated CPUs to this container, then take remain full cores in numa which allocated CPUs to this container. (newly add function **takeRemainCpusForFullCores**)
9. Take full physical cores.
10. Take remain CPUs in the UncoreCache which only allocated CPUs to this container, then take remain CPUs in sockets which allocated CPUs to this container, then take remain CPUs in numa which allocated CPUs to this Pod. (newly add function **takeRemainingCPUsForResize**)
11. Take remain CPUs

- **NUMA Distribute**: Retained CPUs and newly allocated CPUs should be evenly distributed across NUMA nodes.

Code modified in takeByTopologyNUMADistributed：
The allocated should be a subset of the combo. and the number of allocated CPU is not more than distribute number.

Special notes for your reviewer:
UncoreCaches need to be considerd

**2. Add mustKeepCPUs Interface**
What this PR does / why we need it:
When Guaranteed QoS Class Pod scale down without restart with Static CPU management policy alongside InPlacePodVerticalScaling, specify mustKeepCPUsForResize is necessary.

Because if the delay-sensitive service is processed in a guaranteed Pod, and CPU affinity are set for delay-sensitive processes.
If the cpuset changes a lot and do not know which CPU will be removed, the severe CPU migrate will have impact for delay-sensitive process.
In addition, the process in scaled Pod should share newly added CPUs with other Pod for a while(because of cpuset update one Pod by one pod from the start of reconcile period), This may have big impact on latency-sensitive service.

https://github.com/kubernetes/kubernetes/pull/123319#issuecomment-2431197508

Which issue(s) this PR fixes:
Add the interface for mustKeepCPUsForResize when scale down

Does this PR introduce a user-facing change?
The "mustKeepCPUs" in env can be changed by patch command

sig-node meeting:
https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?tab=t.0
